### PR TITLE
Fix native java example spelling

### DIFF
--- a/documentation/android.md
+++ b/documentation/android.md
@@ -134,7 +134,7 @@ var Activity = require('android.app.Activity'),
 This will create a new class in the Java runtime which will extend `android.view.View` which is equivalent to the following code (though please note that we do _not_ generate Java source, but instead generate Dalvik bytecode that gets loaded into the runtime as a class):
 
 ```java
-class View_proxy extend android.view.View {
+class MyView extends android.view.View {
 
 	protected void onDraw(Canvas canvas) {
 		// implementation here


### PR DESCRIPTION
Found two minor Android issues while preparing the HL presentation: Fixing `extend` to `extends` and `View_Proxy` to `MyView` to make it easier to compare it to the Hyperloop example above. /cc @sgtcoolguy 
