### PR TITLE
Android inner classes

### DIFF
--- a/android/plugins/hyperloop/hooks/android/metabase/generate.js
+++ b/android/plugins/hyperloop/hooks/android/metabase/generate.js
@@ -89,6 +89,8 @@ function expandClassDependencies(metabaseJSON, className, done) {
 		// if this is not an inner class, add any inner classes underneath it as dependencies
 		for (var otherClass in metabaseJSON.classes) {
 			if (otherClass.indexOf(className + '$') == 0) {
+				classDef.innerClasses = classDef.innerClasses || [];
+				classDef.innerClasses.push(otherClass);
 				expanded.push(otherClass);
 			}
 		}

--- a/android/plugins/hyperloop/hooks/android/metabase/templates/class.ejs
+++ b/android/plugins/hyperloop/hooks/android/metabase/templates/class.ejs
@@ -193,6 +193,24 @@ for (var propertyName in classDefinition.properties) {
 }
 -%>
 
+// Inner classes
+<%
+if (classDefinition.innerClasses) {
+	for (var ic = 0; ic < classDefinition.innerClasses.length; ic++) {
+		var innerClassName = classDefinition.innerClasses[ic];
+		var baseInnerClassName = innerClassName.slice(innerClassName.indexOf('$') + 1);
+-%>
+Object.defineProperty(<%= sanitizedName %>, '<%= baseInnerClassName %>', {
+	get: function() {
+		return require('<%= innerClassName %>');
+	},
+	enumerable: true
+});
+<%
+	}
+}
+-%>
+
 // Static fields
 <%
 for (var propertyName in classDefinition.properties) {


### PR DESCRIPTION
@hansemannn reported being unable to do the following:

``` js
var test = require("android.os.Build").VERSION.SDK_INT;
```

These changes should fix that issue. There's a few things happening in these commits.
- We now record an enclosing type as a dependency of any inner type (so if you require android.os.Build.VERSION, we mark android.os.Build as a dependency and generate that wrapper)
- We now record inner types as dependencies of enclosing types (so if you require android.os.Build, it'll mark android.os.Build.VERSION and android.os.Build.VERSION_CODES as dependencies and generate those wrappers).
- we properly hang inner types off the enclosing type. (So you can `require('android.os.Build.VERSION');`, or `require('android.os.Build').VERSION;`)
