### PR TITLE
[TIMOB-23179] Hyperloop: Android - Java primitives arrays are wrapped in hyperloop proxies improperly

### DIFF
--- a/android/src/hyperloop/HyperloopUtil.java
+++ b/android/src/hyperloop/HyperloopUtil.java
@@ -78,12 +78,17 @@ abstract class HyperloopUtil {
      * @return
      */
     private static boolean isKnownType(Object item) {
-        // FIXME Look at TypeConverter to see all the ones we really handle
+        // Here's what TypeConverter lists:
+        // short, int, long, float, double, boolean, string, Date, (Object as Function?)
+        // Object[], boolean[], short[], int[], long[], float[], double[]
+        // Since we _always_ end up here due to reflection, we always get boxed types, not primitives
+        // so we check against the boxed types, not primitives (including arrays: for example, Integer[] instanceof Object[] == true)
         return item == null || item instanceof KrollProxy || item instanceof Integer
                 || item instanceof Double || item instanceof Float
                 || item instanceof Byte || item instanceof Short
                 || item instanceof Long || item instanceof HashMap
-                || item instanceof String || item instanceof Boolean || item instanceof Date;
+                || item instanceof String || item instanceof Boolean
+                || item instanceof Date || item instanceof Object[];
     }
 
     /**


### PR DESCRIPTION
Specifically this would fail:

``` js
var Build = require('android.os.Build');
Build.SUPPORTED_ABIS[0];
```

Internally, we'd wrap the String[] into a Java hyperloop proxy, and then try to wrap that in the JS wrapper. For some reason the hyperloop proxy would have an apiName property equal to calling toString() on the Java String[], and we use that value to determine what JS wrapper to use on the object we get back. So it'd fail stating require didn't work.

In this case, we shouldn't be wrapping arrays at all, and should let the bridge convert to a JS array for us.
