### PR TITLE
[TIMOB-23117] Hyperloop: Android: Support calls to super-class

### DIFF
--- a/android/plugins/hyperloop/hooks/android/metabase/templates/class.ejs
+++ b/android/plugins/hyperloop/hooks/android/metabase/templates/class.ejs
@@ -43,7 +43,7 @@ var <%= sanitizedName %> = function() {
 	var result;
 	// Allow the constructor to either invoke the real java constructor, or function as a "wrapping" method that will take
 	// a single argument that is a native hyperloop proxy for this class type and just wraps it in our JS type.
-	if (arguments.length == 1 && arguments[0].isNativeProxy && arguments[0].isInstanceProxy && arguments[0].apiName === '<%= classDefinition.name %>') {
+	if (arguments.length == 1 && arguments[0].isNativeProxy && arguments[0].isInstanceProxy && arguments[0].isInstanceOf('<%= classDefinition.name %>')) {
 		result = arguments[0];
 	}
 	else {
@@ -68,6 +68,14 @@ global.<%= baseName %> = <%= sanitizedName %>;
 var SuperClass = require('<%- classDefinition.superClass %>');
 <%= sanitizedName %>.prototype = Object.create(SuperClass.prototype);
 <%= sanitizedName %>.prototype.constructor = <%= sanitizedName %>;
+
+Object.defineProperty(<%= sanitizedName %>.prototype, 'super', {
+	get: function() {
+		if (!this._hasPointer) return null;
+		return new <%= sanitizedName %>(this.$native.super);
+	},
+	enumerable: true
+});
 <%
 } else {
 -%>
@@ -80,17 +88,6 @@ var SuperClass = require('<%- classDefinition.superClass %>');
 		return '[object ' + this.className + ']';
 	}
 	return null;
-};
-
-<%= sanitizedName %>.isInstanceOf = function (self, cls) {
-	if (typeof cls !== 'function' || typeof self !== 'function') { return false; }
-	while (self) {
-		if (cls === self || self instanceof cls || self.className === cls.className) {
-			return true;
-		}
-		self = self.__superclass__;
-	}
-	return false;
 };
 <%
 }
@@ -119,7 +116,7 @@ if (classDefinition.attributes.indexOf('final') == -1 &&
 	var subclassProxy = Hyperloop.extend('<%= classDefinition.name %>');
 
 	// Generate a JS wrapper for our dynamic subclass
-	var whatever = function() {
+	var SubClass = function() {
 		var result = subclassProxy.newInstance(arguments),
 			instance = this,
 			copy = overrides,
@@ -158,13 +155,11 @@ if (classDefinition.attributes.indexOf('final') == -1 &&
 		this.$native = result;
 		this._hasPointer = result != null;
 		this._private = {};
-
-		// TODO Set up super?!
 	};
 	// it extends the JS wrapper for the parent type
-	whatever.prototype = Object.create(<%= sanitizedName %>.prototype);
-	whatever.prototype.constructor = whatever;
-	return whatever;
+	SubClass.prototype = Object.create(<%= sanitizedName %>.prototype);
+	SubClass.prototype.constructor = SubClass;
+	return SubClass;
 };
 <%
 }

--- a/android/src/hyperloop/BaseProxy.java
+++ b/android/src/hyperloop/BaseProxy.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2015-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -138,7 +138,7 @@ public abstract class BaseProxy extends TiViewProxy {
         return HyperloopUtil.resolveMethod(clazz, methodName, convertedArgs, instanceMethod);
     }
 
-    private Object invokeMethod(Method m, Object receiver, Object[] convertedArgs) {
+    protected Object invokeMethod(Method m, Object receiver, Object[] convertedArgs) {
         m.setAccessible(true); // should offer perf boost since doesn't have to
                                // check security
         try {

--- a/android/src/hyperloop/ClassProxy.java
+++ b/android/src/hyperloop/ClassProxy.java
@@ -71,7 +71,7 @@ public class ClassProxy extends BaseProxy {
                     && !(initArgs[0] instanceof BaseProxy)) {
                 // Wrap the Titanium proxy as a hyperloop proxy of an
                 // instance
-                return ((HyperloopModule) getCreatedInModule()).getProxyFactory()
+                return HyperloopModule.getProxyFactory()
                         .newInstance(convertedArgs[0]);
             }
 
@@ -94,7 +94,7 @@ public class ClassProxy extends BaseProxy {
                 return null;
             }
 
-            return ((HyperloopModule) getCreatedInModule()).getProxyFactory().newInstance(clazz,
+            return HyperloopModule.getProxyFactory().newInstance(clazz,
                     instance);
         } catch (InstantiationException e) {
             Log.e(TAG, "Unable to instantiate class '" + className + "'", e);

--- a/android/src/hyperloop/DynamicSubclassInvocationHandler.java
+++ b/android/src/hyperloop/DynamicSubclassInvocationHandler.java
@@ -1,6 +1,6 @@
 /**
  * Appcelerator Titanium Mobile
- * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2015-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Apache Public License
  * Please see the LICENSE included with this distribution for details.
  */
@@ -26,8 +26,9 @@ class DynamicSubclassInvocationHandler extends HyperloopInvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        if (!this.hp.getOverrides().containsKey(method.getName())) {
+        if (callSuper || !this.hp.getOverrides().containsKey(method.getName())) {
             // TODO What if superclass has marked the method as abstract?
+            callSuper = false; // ok, reset it at the very first chance...
             return HyperloopUtil
                     .unwrap(ProxyBuilder.callSuper(this.hp.getWrappedObject(), method, args));
         }

--- a/android/src/hyperloop/DynamicSubclassProxy.java
+++ b/android/src/hyperloop/DynamicSubclassProxy.java
@@ -31,6 +31,9 @@ public class DynamicSubclassProxy extends ClassProxy {
         if (ip == null) {
             return null;
         }
+        // Hack to set the class name to match the superclass we're extending
+        // FIXME Send in className to ProxyFactory.newInstance?
+        ip.className = this.className;
         ProxyBuilder.setInvocationHandler(ip.getWrappedObject(),
                 new DynamicSubclassInvocationHandler(ip));
         return ip;

--- a/android/src/hyperloop/HyperloopInvocationHandler.java
+++ b/android/src/hyperloop/HyperloopInvocationHandler.java
@@ -24,6 +24,12 @@ class HyperloopInvocationHandler implements InvocationHandler {
 
     protected InstanceProxy hp;
 
+    /**
+     * Special flag we use for forcing subclasses to call up to their super implementations,
+     * ignoring dynamic subclass JS overrides
+     */
+    protected boolean callSuper = false;
+
     protected HyperloopInvocationHandler(InstanceProxy hyperloopProxy) {
         this.hp = hyperloopProxy;
     }

--- a/android/src/hyperloop/HyperloopModule.java
+++ b/android/src/hyperloop/HyperloopModule.java
@@ -9,9 +9,7 @@ package hyperloop;
 
 import java.io.IOException;
 import java.lang.reflect.Modifier;
-import java.util.Map;
 
-import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;

--- a/android/src/hyperloop/HyperloopUtil.java
+++ b/android/src/hyperloop/HyperloopUtil.java
@@ -11,7 +11,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-23117

This adds support for calling methods on the superclass. I didn't test every possible scenario, but the main use case which is when we extend a base Java class in JS and override a method and want to call up into the super implementation. Here's a very simple contrived example:

``` javascript
var CustomView = View.extend({
        isLongClickable: function() {
            Ti.API.info('overridden View#isLongClickable()');
            Ti.API.info('this: ' + this);
            var superResult = this.super.isLongClickable();
            Ti.API.info('result from super: ' + superResult);
            return superResult;
        }
    });
```

Note the explicit use of `this.super`. `super` is itself a keyword in JS, so we need to be explicit and call `this.super.whateverMethod(arg1, arg2);`
