### PR TITLE
[TIMOB-19994] Android: Fix memory leaks in UI proxies

### DIFF
--- a/android/src/hyperloop/ClassProxy.java
+++ b/android/src/hyperloop/ClassProxy.java
@@ -132,4 +132,9 @@ public class ClassProxy extends BaseProxy {
         }
         return array;
     }
+
+    @Override
+    public String toString() {
+        return "ClassProxy@" + Integer.toHexString(hashCode()) + "; " + this.className;
+    }
 }

--- a/android/src/hyperloop/InstanceProxy.java
+++ b/android/src/hyperloop/InstanceProxy.java
@@ -159,7 +159,16 @@ public class InstanceProxy extends BaseProxy {
     }
 
     @Override
+    public void releaseViews() {
+        // release from our cache, because we're cleaning this view up
+        HyperloopModule.getProxyFactory().release(this);
+        super.releaseViews(); // do normal cleanup for the view hierarchy
+        super.release(); // now release the underlying JS object
+    }
+
+    @Override
     public void release() {
+        // ensure we release from our cache
         HyperloopModule.getProxyFactory().release(this);
         super.release();
     }
@@ -184,5 +193,10 @@ public class InstanceProxy extends BaseProxy {
         superCopy.overrides = this.overrides;
         superCopy.isSuper = true; // we have to specially mark this one, so that just before method calls we let handler know not to use overrides
         return superCopy;
+    }
+
+    @Override
+    public String toString() {
+        return "InstanceProxy@" + Integer.toHexString(hashCode()) + "; " + getWrappedObject();
     }
 }


### PR DESCRIPTION
https://jira.appcelerator.org/browse/TIMOB-19994

So, basically I have two caches in the hyperloop module: class proxies and instance proxies. The class proxy cache is an LRU cache with strong references, holding the most recent 25 Java class proxies accessed from hyperloop. This is a performance-enhancing cache.

The second is an instance proxy cache, meant to ensure that we re-use the same Hyperloop/Java proxy for the same Java object (so if you `new` up some Java object from JS, that same object and proxy are re-used when it gets passed back in as a method argument, or assigned to some field). This cache is tricky, because we want to make sure we re-use existing instances, but we don't want the cache to hold strong references to either the wrapped Java Object or the InstanceProxy we wrapped it in (or else they'll never get GC'd).

This PR fixes the InstanceProxy cache in a couple ways:
- The key was held weakly (to the wrapped Java object), but the InstanceProxy value wasn't. Now we wrap it explicitly in a WeakReference so just holding it in the cache doesn't prevent the proxy and wrapped Java Object from getting GC'd.
- When we generated wrapping "HyperloopViews" to interface between native android.view.Views and Ti.UI.Views, we didn't seem to clean everything up. Now when we get asked to "releaseViews" we take that to mean we should clean up the HyperloopView, the entry in our InstanceProxy cache, and the JS Object holding the proxy. 

Unfortunately the process to test that this actually works isn't easy, and I'm not 100% sure _every_ case is handled yet. But I did pepper Android's ReferenceTable and the hyperloop code with lots of debug logs to track the lifecycle of objects. Then I used the hyperloop-examples app and navigated to the alert example and then back to the main listing. Then I forced a garbage collection and pored over the output to ensure I saw that the 3 InstanceProxies we generated ended up getting destroyed from the reference table and removed from my own cache.

The only uncertainty I had was whether instance proxies we generated to modify UI elements (like LayoutParams) got cleaned up all over. I did see the JS object got destroyed, but had no way to determine if the entry in the InstanceProxy cache was null (aka there's no leak on the JS side, but I couldn't confirm no leak on the Java side).

The only way I can think to verify that is to make our WeakReferences in the instance proxy cache use a ReferenceQueue and have a Thread polling on that queue spitting out to logs when it sees a reference is ready for GC. Ugh.
