### PR TITLE
[TIMOB-23526] Locks down the version of cocoapod hyperloop uses.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '0.38.0'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,62 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (0.9.1)
+    cocoapods (0.38.0)
+      activesupport (>= 3.2.15)
+      claide (~> 0.9.1)
+      cocoapods-core (= 0.38.0)
+      cocoapods-downloader (~> 0.9.1)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-stats (~> 0.5.3)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.3.0)
+      nap (~> 0.8)
+      xcodeproj (~> 0.26.2)
+    cocoapods-core (0.38.0)
+      activesupport (>= 3.2.15)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 0.8.0)
+    cocoapods-downloader (0.9.3)
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-stats (0.5.3)
+      nap (~> 0.8)
+    cocoapods-trunk (0.6.4)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (0.4.5)
+    colored (1.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.9.0)
+    molinillo (0.3.1)
+    nap (0.8.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.26.3)
+      activesupport (>= 3)
+      claide (~> 0.9.1)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (= 0.38.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23526

This locks down the version of cocoapods that we are using and makes the pod command run through bundler which is a good practice in the ruby world.

While this doesn't actually solve the problem of using a version of cocoapod newer than 0.39.0, it does however allow cocoapods to be used again for hyperloop projects. 
Not having a Gemfile when you have a ruby dependency is akin to not having a package.json in the node world.

It's good practice in the ruby world to use bundler when calling ruby commands aka `bundle exec pod...` as opposed to `pod ....`

This buys us time in the short run and in the longer run makes the ruby dependencies more predictable.  
