### PR TITLE
[TIMOB-23652] Fix Swift-compiling in iOS10

### DIFF
--- a/metabase/ios/lib/swift.js
+++ b/metabase/ios/lib/swift.js
@@ -11,13 +11,18 @@ var fs = require('fs'),
  * generate Swift AST output from a swift file
  */
 function generateSwiftAST (sdkPath, iosMinVersion, xcodeTargetOS, fn, callback) {
-	var args = ['swiftc', '-sdk', sdkPath, '-dump-ast', fn];	
+	var args = ['swiftc', '-sdk', sdkPath, '-dump-ast', fn];
 	if (xcodeTargetOS === 'iphoneos' || xcodeTargetOS === 'iphonesimulator') {
 		args.push('-target');
-		// armv7 for devices, i386 for sims. But to note that we can do armv7s and arm64 here
-		args.push((xcodeTargetOS === 'iphoneos' ? 'armv7' : 'i386') + '-apple-ios' + iosMinVersion);
+		if (xcodeTargetOS === 'iphoneos') {
+			// armv7 for all devices. Note that we also could use armv7s or arm64 here
+			args.push('armv7-apple-ios' + iosMinVersion);
+		} else {
+			var simArch = process.arch === 'i386' ? 'i386' : 'x86_64';
+			args.push(simArch + '-apple-ios' + iosMinVersion);
+		}
 	}
- 	var child = spawn('xcrun', args),
+	var child = spawn('xcrun', args),
 		buf = '';
 	// swiftc -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.0.sdk -dump-ast MySwift.swift
 	child.on('error', callback);
@@ -181,7 +186,7 @@ function generateSwiftMangledClassName (appName, className) {
 function generateSwiftMetabase (buildDir, sdk, sdkPath, iosMinVersion, xcodeTargetOS, metabase, framework, fn, callback) {
 	generateSwiftAST(sdkPath, iosMinVersion, xcodeTargetOS, fn, function (err, buf) {
 		if (err) {
-			return callback(err, buf); 
+			return callback(err, buf);
 		}
 		var classes = {},
 			classdef,


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23652

Same as https://github.com/appcelerator/hyperloop.next/pull/40, but with dynamic simulator arch detection.
