### PR TITLE
[TIMOB-23708] Android: Assets dir inside AAR is optional, handle when doesn't exist

### DIFF
--- a/android/plugins/hyperloop/hooks/android/hyperloop.js
+++ b/android/plugins/hyperloop/hooks/android/hyperloop.js
@@ -304,6 +304,8 @@ exports.cliVersion = '>=3.2';
 		 * extracting like a zipfile
 		 * copying resources around
 		 *
+		 * http://tools.android.com/tech-docs/new-build-system/aar-format
+		 *
 		 * @returns {Array[String]} paths to JAR files we extracted
 		 **/
 		function handleAAR(aarFile, finished) {
@@ -339,7 +341,10 @@ exports.cliVersion = '>=3.2';
 						function (cb) {
 							var src = path.join(extractedDir, 'assets'),
 								dest = path.join(cli.argv['project-dir'], 'build', 'android', 'assets');
-
+							// assets is optional, skip if doesn't exist!
+							if (!afs.exists(src)) {
+								return cb();
+							}
 							afs.copyDirRecursive(src, dest, cb, {logger: logger});
 						},
 						// Find libs/*.jar


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/

@miga on ti.slack was seeing this issue with google's firebase-message.aar

Basically my code assumed and assets directory always existed in an AAR file. According to http://tools.android.com/tech-docs/new-build-system/aar-format it is an optional dir, so I need to check for existence and skip copying if it doesn't exist.

```
[ERROR] Failed to extract/handle aar zip: /Users/appdev/Development/Titanium_Workspace/Active/hyperloopFCM/platform/android/firebasemessaging.aar

[ERROR] An error occurred during build after 1s 594ms
[ERROR] ENOENT, stat '/Users/appdev/Development/Titanium_Workspace/Active/hyperloopFCM/build/hyperloop/android/firebasemessaging/assets'
```
