### PR TITLE
[TIMOB-23722] Skip API availability check for tvOS and watchOS platforms

### DIFF
--- a/metabase/ios/src/parser.cpp
+++ b/metabase/ios/src/parser.cpp
@@ -317,13 +317,13 @@ namespace hyperloop {
 		if (size > 0) {
 			bool unavailable = false;
 			for (int c = 0; c < size; c++) {
-                // We only care for ios, so skip this platform if it's anything else
-                auto platformNameCString = clang_getCString(availability[c].Platform);
-                std::string platformName = platformNameCString;
-                if (platformName.compare("ios") != 0) {
-                    continue;
-                }
-                
+				// We only care for ios, so skip this platform if it's anything else
+				auto platformNameCString = clang_getCString(availability[c].Platform);
+				std::string platformName = platformNameCString;
+				if (platformName.compare("ios") != 0) {
+					continue;
+				}
+
 				if (availability[c].Unavailable) {
 					unavailable = true;
 				}


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23722

Interface definitions annotated with something like `NS_CLASS_AVAILABLE(NA, 7_0) __TVOS_PROHIBITED __WATCHOS_PROHIBITED` caused Hyperloop to skip it even though we should only be concerned about iOS Platform availability. This fix checks the platform first and skips the availability check if it is anything else than iOS.
