### PR TITLE
[TIMOB-23722] Skip API availability check for tvOS and watchOS platforms (1.2.X Backport)

### DIFF
--- a/metabase/ios/src/parser.cpp
+++ b/metabase/ios/src/parser.cpp
@@ -317,13 +317,13 @@ namespace hyperloop {
 		if (size > 0) {
 			bool unavailable = false;
 			for (int c = 0; c < size; c++) {
-                // We only care for ios, so skip this platform if it's anything else
-                auto platformNameCString = clang_getCString(availability[c].Platform);
-                std::string platformName = platformNameCString;
-                if (platformName.compare("ios") != 0) {
-                    continue;
-                }
-                
+				// We only care for ios, so skip this platform if it's anything else
+				auto platformNameCString = clang_getCString(availability[c].Platform);
+				std::string platformName = platformNameCString;
+				if (platformName.compare("ios") != 0) {
+					continue;
+				}
+
 				if (availability[c].Unavailable) {
 					unavailable = true;
 				}


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23722

https://github.com/appcelerator/hyperloop.next/pull/60 backported to HL 1.2.X
