### PR TITLE
[TIMOB-23815] Hyperloop Android - Error creating proxy after HyperLoop version 1.2.6

### DIFF
--- a/android/src/hyperloop/HyperloopModule.java
+++ b/android/src/hyperloop/HyperloopModule.java
@@ -14,6 +14,7 @@ import org.appcelerator.kroll.KrollModule;
 import org.appcelerator.kroll.annotations.Kroll;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
+import org.appcelerator.titanium.TiContext;
 import org.appcelerator.titanium.util.TiUIHelper;
 import hyperloop.HyperloopUtil;
 
@@ -83,6 +84,10 @@ public class HyperloopModule extends KrollModule {
 
     public HyperloopModule() {
         super();
+    }
+
+    public HyperloopModule(TiContext tiContext) {
+        this();
     }
 
     @Kroll.onAppCreate


### PR DESCRIPTION
This reverts commit 71e662870afb41da4bd30d5e51ccb9b7e8ee2c82.

https://jira.appcelerator.org/browse/TIMOB-23815

This adds back the TiContext constructor, which should be removed only on master intended for Titanium 6+ (where TiContext has been removed).
