### PR TITLE
[TIMOB-20297] Support hyphens in require replace regex (2_0_X)

### DIFF
--- a/iphone/plugin/hyperloop.js
+++ b/iphone/plugin/hyperloop.js
@@ -374,7 +374,7 @@ HyperloopiOSBuilder.prototype.patchJSFile = function patchJSFile(sourceFilename,
 	// get the result source code in case it was transformed and replace all system framework
 	// require() calls with the Hyperloop layer
 	var newContents = (this.parserState.getSourceCode() || contents).replace(
-		/require\s*\([\\"']+([\w_/-\\.]+)[\\"']+\)/ig,
+		/require\s*\([\\"']+([\w_/\-\\.]+)[\\"']+\)/ig,
 		function (orig, match) {
 			// hyperloop includes will always have a slash
 			var tok = match.split('/');


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-20297

Hyperloop replaces require calls to native classes with the Hyperloop
layer. The regex used to detect requires with native classes could not
handle hyphens. This commit fixes the regex.
