### PR TITLE
[TIMOB-24057] Adapt native CocoaPods build behavior (2_0_X)

### DIFF
--- a/iphone/plugin/hyperloop.js
+++ b/iphone/plugin/hyperloop.js
@@ -227,7 +227,7 @@ HyperloopiOSBuilder.prototype.getSystemFrameworks = function getSystemFrameworks
  */
 HyperloopiOSBuilder.prototype.generateCocoaPods = function generateCocoaPods(callback) {
 	// attempt to handle cocoapods for third-party frameworks
-	hm.metabase.generateCocoaPods(this.hyperloopBuildDir, this.builder.projectDir, this.builder.xcodeAppDir, this.builder.xcodeTargetOS, this.builder.iosSdkVersion, this.builder.minIosVer, this.builder.xcodeEnv.executables, function (err, settings, symbols) {
+	hm.metabase.generateCocoaPods(this.hyperloopBuildDir, this.builder, function (err, settings, symbols) {
 		if (!err) {
 			this.buildSettings = settings;
 			symbols && Object.keys(symbols).forEach(function (k) {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24057

Changes the CocoaPods build to run with the same build configuration und to use the same build output dir as our main iOS build.
