### PR TITLE
Windows: Implement debug mode

### DIFF
--- a/windows/include/Hyperloop.hpp
+++ b/windows/include/Hyperloop.hpp
@@ -107,25 +107,30 @@ public:
 	static void JSExportInitialize();
 };
 
-class HYPERLOOP_EXPORT Hyperloop : public Titanium::Module, public JSExport<Hyperloop>
+class HYPERLOOP_EXPORT HyperloopModule : public Titanium::Module, public JSExport<HyperloopModule>
 {
 	public:
-		Hyperloop(const JSContext&) TITANIUM_NOEXCEPT;
+		HyperloopModule(const JSContext&) TITANIUM_NOEXCEPT;
 
-		virtual ~Hyperloop()                   = default;
-		Hyperloop(const Hyperloop&)            = default;
-		Hyperloop& operator=(const Hyperloop&) = default;
+		virtual ~HyperloopModule()                   = default;
+		HyperloopModule(const HyperloopModule&)            = default;
+		HyperloopModule& operator=(const HyperloopModule&) = default;
 #ifdef TITANIUM_MOVE_CTOR_AND_ASSIGN_DEFAULT_ENABLE
-		Hyperloop(Hyperloop&&)                 = default;
-		Hyperloop& operator=(Hyperloop&&)      = default;
+		HyperloopModule(HyperloopModule&&)                 = default;
+		HyperloopModule& operator=(HyperloopModule&&)      = default;
 #endif
 
 		static void JSExportInitialize();
 
 		static JSValue Convert(const JSContext&, HyperloopInvocation::Instance^);
 		static HyperloopInvocation::Instance^ Convert(const JSContext&, const JSValue&, const Windows::UI::Xaml::Interop::TypeName);
+		
+		TITANIUM_PROPERTY_IMPL_DEF(bool, debug);
 
+		TITANIUM_PROPERTY_DEF(debug);
 		TITANIUM_FUNCTION_DEF(exists);
 		TITANIUM_FUNCTION_DEF(require);
+	private:
+		bool debug__{ false };
 };
 #endif // _HYPERLOOP_HPP_

--- a/windows/manifest
+++ b/windows/manifest
@@ -14,6 +14,7 @@ copyright: Copyright (c) 2016 Appcelerator, Inc.
 name: hyperloop
 moduleid: hyperloop
 moduleIdAsIdentifier: Hyperloop
+classname: HyperloopModule
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: windows
 minsdk: 6.1.0


### PR DESCRIPTION
To make development easier. 

- Module should have at least one ref class to make Microsoft certificate pass
- Change module class name to `HyperloopModule`
- Implement debug mode

Hyperloop debug mode is useful to get native exception when Hyperloop reflection fails. Especially `require` throws JavaScript exception with detailed information when it fails. When debug mode is off, `require` just silently returns `null` and you don't get native exception.

```javascript
require('hyperloop').debug = true;
```
