### PR TITLE
[TIMOB-24175] Android: Use native toString() for prototype

### DIFF
--- a/android/plugins/hyperloop/hooks/android/metabase/templates/interface.ejs
+++ b/android/plugins/hyperloop/hooks/android/metabase/templates/interface.ejs
@@ -98,10 +98,13 @@ global.<%= baseName %> = <%= sanitizedName %>;
 };
 
 <%= sanitizedName %>.prototype.toString = function() {
-	if (this._hasPointer) {
-		return "[object " + this.className + "]";
-	}
-	return null;
+	if (!this._hasPointer) return null;
+
+	var result = this.$native.callNativeFunction({
+		func: 'toString',
+		instanceMethod: true
+	});
+	return result;
 };
 
 <%= sanitizedName %>.isInstanceOf = function (self, cls) {


### PR DESCRIPTION
- Use native `toString()` method for object prototype

###### TEST CASE
```Javascript
var EditableFactory = require('android.text.Editable.Factory'),
    editable = new EditableFactory().newEditable('test');

Ti.API.info(editable.toString());
```
```
test
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-24175)