### PR TITLE
Use 2.1.0 again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
We bumped to 2.1.1 a few weeks ago, but to keep the semantic versioning correct, we should use one version to test the different related features and thats supposed to be 2.1.0.