### PR TITLE
[TIMOB-24102] Implement cast, better method resolution

### DIFF
--- a/windows/include/Hyperloop.hpp
+++ b/windows/include/Hyperloop.hpp
@@ -141,6 +141,7 @@ public:
 
 	static void JSExportInitialize();
 
+	TITANIUM_FUNCTION_DEF(cast);
 	TITANIUM_FUNCTION_DEF(addEventListener);
 	TITANIUM_FUNCTION_DEF(removeEventListener);
 
@@ -165,7 +166,7 @@ class HYPERLOOP_EXPORT HyperloopModule : public Titanium::Module, public JSExpor
 		static void JSExportInitialize();
 
 		static JSValue Convert(const JSContext&, HyperloopInvocation::Instance^);
-		static HyperloopInvocation::Instance^ Convert(const JSContext&, const JSValue&, const Windows::UI::Xaml::Interop::TypeName);
+		static HyperloopInvocation::Instance^ Convert(const JSValue&, const Windows::UI::Xaml::Interop::TypeName);
 		static JSObject CreateObject(const JSContext&, HyperloopInvocation::Instance^);
 		
 		TITANIUM_PROPERTY_IMPL_DEF(bool, debug);


### PR DESCRIPTION
[[TIMOB-24102]](https://jira.appcelerator.org/browse/TIMOB-24102) Implement cast, more precise method overload handling and cache

- Implement LRU Cache (A cache that deletes the least-recently-used items) for faster method resolution
- Implement `cast` method to cast object to specific type
- `require` for event arguments (`TappedRoutedEventArgs` etc) is not needed for now
- Implement better method overload handling with given type

For the method overload resolution, you should be able to select following method signatures with `cast', for instance.

- `System.Math.Abs(double)`
- `System.Math.Abs(System.Int32)`
- `System.Math.Abs(System.UInt32)`

See also: [C#: System.Math](https://msdn.microsoft.com/en-us/library/system.math(v=vs.110).aspx)

In this case you can now use `cast` to specify specific type parameter. If nothing is specified `double` is assumed.

- System_Math.Abs(`require('System.Double')`.cast(number));
- System_Math.Abs(`require('System.Int32')`.cast(number));
- System_Math.Abs(`require('System.UInt32')`.cast(number));

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
win.addEventListener('open', function () {

    var Button = require('Windows.UI.Xaml.Controls.Button');
    var button = new Button();

    // Set JavaScript string for System.Object property
    button.Content = "PUSH PUSH";

    // No need to require TappedRoutedEventArgs for now in order to handle events
    button.addEventListener('Tapped', function (e) {
        // button.Content should be a System.Object
        Ti.API.info(button.Content.ToString());

        // Cast System.Object to System.String and then call String methods
        var content_str = require('System.String').cast(button.Content);
        Ti.API.info('button.Content length = ' + content_str.Length);
        alert('This should be true: ' + content_str.EndsWith(' PUSH'));
    });

    win.add(button);

    var System_Math = require('System.Math');

    // Call System.Math.Abs(double); (implicit)
    Ti.API.info(System_Math.Abs(-1.23));

    // Call System.Math.Abs(double); (explicit)
    Ti.API.info(System_Math.Abs(require('System.Double').cast(-1.23)));

    // Call System.Math.Abs(Int32);
    Ti.API.info(System_Math.Abs(require('System.Int32').cast(-1.23)));
});
win.open();
```