### PR TITLE
[TIMOB-24198] Force include Foundation framework

### DIFF
--- a/metabase/ios/lib/metabase.js
+++ b/metabase/ios/lib/metabase.js
@@ -180,7 +180,7 @@ function generateMetabase (buildDir, sdk, sdkPath, iosMinVersion, includes, excl
 
 	// Foundation header always needs to be included
 	var absoluteFoundationHeaderRegex = /Foundation\.framework\/Headers\/Foundation\.h$/;
-	var systemFoundationHeaderRegex = /^[<"]Foundation\/Foundation\.h[<"]$/;
+	var systemFoundationHeaderRegex = /^[<"]Foundation\/Foundation\.h[>"]$/;
 	var isFoundationIncluded = includes.some(function(header) {
 		return systemFoundationHeaderRegex.test(header) || absoluteFoundationHeaderRegex.test(header);
 	});

--- a/metabase/ios/test/generate_test.js
+++ b/metabase/ios/test/generate_test.js
@@ -276,7 +276,7 @@ describe('generate', function () {
 				should(instance.className).be.equal('NSString');
 				should(instance.$native).be.an.object;
 
-				// ... and if INPreferences is genreated correctly, which does not work without
+				// ... and if INPreferences is generated correctly, which does not work without
 				// explicitly including Foundation framework
 				var INPreferences = require(nodePath.join(buildDir, 'intents/inpreferences.js'));
 				should(INPreferences).be.a.function;


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24198

Fixes a metabase parsing issue for headers that do not explicitly include the Foundation framework themselves.