### PR TITLE
[TIMOB-24057] Always build pods for all archs

### DIFF
--- a/metabase/ios/lib/metabase.js
+++ b/metabase/ios/lib/metabase.js
@@ -540,13 +540,9 @@ function runCocoaPodsBuild (basedir, builder, callback) {
 			'-alltargets',
 			'IPHONEOS_DEPLOYMENT_TARGET=' + minSDKVersion,
 			'-sdk', sdk,
-			'SYMROOT=' + productsDirectory
+			'SYMROOT=' + productsDirectory,
+			'ONLY_ACTIVE_ARCH=NO'
 		];
-	if (builder.simHandle) {
-		// Manually set the arch for simulator builds since we cannot use -destination
-		// because the Pods project has no scheme.
-		args.push('-arch', process.arch === 'x64' ? 'x86_64' : 'i386');
-	}
 	var buildOutDir = path.join(productsDirectory, buildConfigurationName + '-' + sdkType),
 		runDir = path.join(basedir, 'Pods'),
 		child = spawn(xcodesettings.xcodebuild, args, {cwd:runDir});


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24057

Building the pods for a specific arch and the app for all available archs was causing issues during linking. The `ONLY_ACTIVE_ARCH=NO` flag is set in the app's Xcode project [here](https://github.com/appcelerator/titanium_mobile/blob/master/iphone/cli/commands/_build.js#L2962) so we need to do the same for pods. 