### PR TITLE
empty impl for Builder plugin (Windows)

### DIFF
--- a/plugins/windows/hyperloop.js
+++ b/plugins/windows/hyperloop.js
@@ -1,0 +1,26 @@
+/**
+ * Hyperloop ® plugin for Windows
+ * Copyright (c) 2015-2017 by Appcelerator, Inc.
+ * All Rights Reserved. This library contains intellectual
+ * property protected by patents and/or patents pending.
+ */
+'use strict';
+
+/** The plugin's identifier */
+exports.id = 'hyperloop';
+
+/** The Titanium CLI version that this hook is compatible with */
+exports.cliVersion = '>=3.2';
+
+(function () {
+	// Hyperloop Build for Windows
+	function HyperloopWindowsBuilder (logger, config, cli, appc, hyperloopConfig, builder) {
+
+	}
+
+	HyperloopWindowsBuilder.prototype.init = function (next) {
+		next();
+	};
+
+	module.exports = HyperloopWindowsBuilder;
+})();


### PR DESCRIPTION
Potential fix for #127 . 

- Copy this `hyperloop.js` to `C:\ProgramData\Titanium\plugins\hyperloop\VERSION\hooks\windows`

![hyperloop](https://cloud.githubusercontent.com/assets/1661068/23447937/7ade7b4e-fe91-11e6-8698-7996c8c9d581.png)
