### PR TITLE
[TIMOB-24461] Allow spaces in require checks

### DIFF
--- a/android/plugins/hyperloop/hooks/android/hyperloop.js
+++ b/android/plugins/hyperloop/hooks/android/hyperloop.js
@@ -42,7 +42,7 @@ exports.cliVersion = '>=3.2';
 		jars = [],
 		aars = {},
 		cleanup = [],
-		requireRegex = /require\s*\([\\"']+([\w_\/-\\.\\*]+)[\\"']+\)/ig;
+		requireRegex = /require\s*\(\s*[\\"']+([\w_\/-\\.\\*]+)[\\"']+\s*\)/ig;
 
 	/*
 	 Config.
@@ -483,7 +483,7 @@ exports.cliVersion = '>=3.2';
 					found = [];
 				logger.trace('Searching for hyperloop requires in: ' + file);
 				(contents.match(requireRegex) || []).forEach(function (m) {
-					var re = /require\s*\([\\"']+([\w_\/-\\.\\*]+)[\\"']+\)/i.exec(m),
+					var re = /require\s*\(\s*[\\"']+([\w_\/-\\.\\*]+)[\\"']+\s*\)/i.exec(m),
 						className = re[1],
 						lastIndex,
 						validPackage = false,


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24461

This fixes an issue in the regex used to check for Hyperloop usage fails to recognize require statements like `require( 'android.app.Activity' )` (Note the extra spaces)