### PR TITLE
Bump up version for Windows

### DIFF
--- a/windows/manifest
+++ b/windows/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.0
+version: 2.1.0
 apiversion: 2
 architectures: ARM x86
 description: hyperloop


### PR DESCRIPTION
`manifest.version` for Windows should have been `2.1.0` to align with other platforms.
