### PR TITLE
[TIMOB-23902] Use boxed expression to return enum value

### DIFF
--- a/metabase/ios/lib/generate/util.js
+++ b/metabase/ios/lib/generate/util.js
@@ -516,7 +516,7 @@ function getObjCReturnResult (value, name, returns, asPointer) {
 			return returns + ' (' + name + ' == nil) ? (id)[NSNull null] : (id)[HyperloopPointer pointer:(const void *)' + asPointer + name + ' encoding:@encode(' + value.value + ')];';
 		}
 		case 'enum': {
-			return returns + ' [HyperloopPointer pointer:(const void *)' + asPointer + name + ' encoding:@encode(' + value.value + ')];';
+			return returns + ' @(' + name + ');';
 		}
 		case 'struct': {
 			if (value.framework && value.filename) {

--- a/metabase/ios/test/util_test.js
+++ b/metabase/ios/test/util_test.js
@@ -1,0 +1,15 @@
+var should = require('should');
+var util = require('../lib/generate/util');
+
+describe('util', function () {
+  describe('getObjCReturnResult()', function() {
+    it('should use boxed expression to return enums', function() {
+      var variableName = 'arg1';
+      var value = {
+        type: 'enum'
+      };
+      var returnResult = util.getObjCReturnResult(value, variableName);
+      should(returnResult).be.equal('return @(' + variableName + ');');
+    });
+  });
+});


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23902

As enums are always integral values there is no need to wrap them in a `HyperloopPointer`. The used Objective-C boxed expression will always create a new `NSNumber` object using the appropriate initializer method for the enum type.