### PR TITLE
[TIMOB-23679] Properly detect declaration node

### DIFF
--- a/metabase/ios/lib/generate/custom.js
+++ b/metabase/ios/lib/generate/custom.js
@@ -790,7 +790,16 @@ function makeHyperloopClassFromCall (state, node) {
 	classSpec.name = toJSObject(program, node.arguments[0]);
 	classSpec.extends = toJSObject(program, node.arguments[1], 'NSObject');
 	classSpec.implements = toJSObject(program, node.arguments[2]);
-	classSpec.variable = node.parentNode.declarations[0].id.name;
+	var declarationNode = null;
+	node.parentNode.declarations.forEach(function(declNode) {
+		if (declNode.init === node) {
+			declarationNode = declNode;
+		}
+	});
+	if (declarationNode === null) {
+		throw new JSParseError('Unable determine designated variable for Hyperloop.defineClass call.');
+	}
+	classSpec.variable = declarationNode.id.name;
 	classSpec.location = node.loc;
 	classSpec.importClasses = {};
 	classSpec.importClasses[classSpec.extends] = 1;


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-23679

This fixes crashes for `Hyperloop.defineClass` custom classes with minified code e.g. for device builds.

@hansemannn, can you please check with your device? I could only verify it with `-T device --build-only` and some debugging during the build so far.