### PR TITLE
Bump master to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "hyperloop",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",
     "titanium",
     "hyperloop",
     "android",
-    "ios"
+    "ios",
+    "windows"
   ],
   "author": "Jeff Haynie",
   "contributors": [
@@ -28,6 +29,9 @@
     },
     {
       "name": "Jan Vennemann"
+    },
+    {
+      "name": "Kota Iguchi"  
     }
   ],
   "license": "UNLICENSED",

--- a/windows/manifest
+++ b/windows/manifest
@@ -2,13 +2,13 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.0
+version: 2.2.0
 apiversion: 2
 architectures: ARM x86
 description: hyperloop
 author: Appcelerator
 license: Appcelerator Commercial License
-copyright: Copyright (c) 2016 Appcelerator, Inc.
+copyright: Copyright (c) 2016-Present Appcelerator, Inc.
 
 # these should not be edited
 name: hyperloop


### PR DESCRIPTION
@infosia I noticed that the Hyperloop version for Windows is still hardocded in `windows/manifest`. Could you adjust the build.sh to package it all together? The `manifest` file has a `version: VERSION` in it that it that is replaced during packaging. 

Same thing for the plugin that should be merged together with iOS and Android, so we have a structure like:
- `<project-dir>/plugins/hyperloop/<version>/hooks/windows`
- `<project-dir>/plugins/hyperloop/<version>/hooks/android`
- `<project-dir>/plugins/hyperloop/<version>/hooks/ios`