### PR TITLE
[TIMOB-24571]  Fix Windows minsdk

### DIFF
--- a/windows/manifest
+++ b/windows/manifest
@@ -17,4 +17,4 @@ moduleIdAsIdentifier: Hyperloop
 classname: HyperloopModule
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: windows
-minsdk: 6.1.0
+minsdk: 6.0.4


### PR DESCRIPTION
[[TIMOB-24571]](https://jira.appcelerator.org/browse/TIMOB-24571) Hyperloop 2.1.0 should work with Titanium SDK `6.0.4`.
