### PR TITLE
[2_1_X] Revert "windows minsdk should be 6.0.4"

### DIFF
--- a/windows/manifest
+++ b/windows/manifest
@@ -17,4 +17,4 @@ moduleIdAsIdentifier: Hyperloop
 classname: HyperloopModule
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: windows
-minsdk: 6.0.4
+minsdk: 6.1.0


### PR DESCRIPTION
For `2_1_X` branch.
Revert #148 `windows minsdk should be 6.0.4` due to latest release decision.

This reverts commit 188f29ed155fc01bd65ea7a15a6ff6bf86561c83.
