### PR TITLE
[TIMOB-24383] Make sure to use correct prototype for existing wrappers (2_1_X)

### DIFF
--- a/metabase/ios/templates/class.ejs
+++ b/metabase/ios/templates/class.ejs
@@ -18,14 +18,24 @@ var <%= data.superclass.name %> = require('/hyperloop/<%= data.superclass.framew
  * @class
  */
 function <%= data.class.name %> (pointer) {
-	if (pointer) {
-		var oldWrapper = Hyperloop.getWrapper(pointer.$native ? pointer.$native : pointer);
-		if (oldWrapper) return oldWrapper;
+	if (!(this instanceof <%= data.class.name %>)) {
+		throw new TypeError('Cannot instantiate a class by calling it as a function');
 	}
-	if (!(this instanceof <%= data.class.name %>)) { throw new TypeError('Cannot instantiate a class by calling it as a function'); }
+
 	if (!$init) {
 		$initialize();
 	}
+
+	if (pointer) {
+		var oldWrapper = Hyperloop.getWrapper(pointer.$native ? pointer.$native : pointer);
+		if (oldWrapper) {
+			if (oldWrapper.__proto__ !== this.__proto__) {
+				oldWrapper = Object.setPrototypeOf(oldWrapper, this.__proto__);
+			}
+			return oldWrapper;
+		}
+	}
+
 	if (!pointer) {
 		pointer = Hyperloop.createProxy({
 			class: '<%= data.class.mangledName || data.class.name %>',
@@ -181,8 +191,8 @@ function $initialize () {
  * ticore compatibility with ES6
  */
 Object.setPrototypeOf = Object.setPrototypeOf || function(obj, proto) {
-  obj.__proto__ = proto;
-  return obj;
+	obj.__proto__ = proto;
+	return obj;
 }
 
 module.exports = <%= data.class.name %>;


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24383

A wrapper object is stored with the prototype it was first created with. Under certain use cases it can happen that the wrapper for a pointer is generated for a less specific type in the inheritance chain like NSObject. All further access to that wrapper would then use the NSObject prototype even if casted to their specific type, rendering all methods and properties from the specific wrapper implementation unusable. This commit fixes that by making sure to always set the correct prototype before returning an existing wrapper instance.