### PR TITLE
[TIMOB-24291] Properly resolve types with lightweight generics

### DIFF
--- a/metabase/ios/lib/generate/custom.js
+++ b/metabase/ios/lib/generate/custom.js
@@ -854,6 +854,9 @@ function encodeFriendlyType (type, imports) {
 		case 'object':
 		case 'NSObject': return '@';
 		default: {
+			if (type.indexOf('<') !== -1) {
+				type = type.substring(0, type.indexOf('<'));
+			}
 			imports && (imports[type] = 1);
 			return '[' + type + ']';
 		}


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24291

The extra type information from lightweight generics can be omitted because it doesn't affect the encoding of collection classes.