### PR TITLE
[TIMOB-24720] Set ecmaVersion on acorn.parse (2_1_X)

### DIFF
--- a/metabase/ios/lib/generate/custom.js
+++ b/metabase/ios/lib/generate/custom.js
@@ -591,7 +591,7 @@ Parser.prototype.parse = function (buf, fn, state) {
 	// turn it into a buffer
 	buf = buf.toString();
 
-	var ast = acorn.parse(buf, { locations: true }),
+	var ast = acorn.parse(buf, { ecmaVersion: 6, locations: true }),
 		mutated,
 		prop;
 


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24720

I guess we eventually want to go all in on the babel ecosystem here too but this stops acorn from choking on ES6 syntax for now. 6 is the highest ECMAScript version achievable with the acorn@^2.4.0 (installs 2.7.0)