### PR TITLE
[TIMOB-24862] Pass correct SDK version to CocoaPods build (2_1_X)

### DIFF
--- a/metabase/ios/lib/metabase.js
+++ b/metabase/ios/lib/metabase.js
@@ -537,7 +537,8 @@ function runCocoaPodsBuild (basedir, builder, callback) {
 		minSDKVersion = builder.minIosVer,
 		xcodesettings = builder.xcodeEnv.executables,
 		spawn = require('child_process').spawn,
-		sdk = sdkType + sdkVersion,
+		// Make sure SDK version is always in MAJOR.MINOR format
+		sdk = sdkType + (/\d+\.\d+\.\d+/.test(sdkVersion) ? sdkVersion.substring(0, sdkVersion.lastIndexOf('.')) : sdkVersion),
 		productsDirectory = path.join(basedir, 'build/iphone/build/Products'),
 		buildConfigurationName = builder.xcodeTarget,
 		args = [


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24862

2_1_X backport of #181 