### PR TITLE
[TIMOB-24539] Process .aar files in series (2_1_X)

### DIFF
--- a/android/plugins/hyperloop/hooks/android/hyperloop.js
+++ b/android/plugins/hyperloop/hooks/android/hyperloop.js
@@ -350,7 +350,7 @@ exports.cliVersion = '>=3.2';
 			},
 			// Handle AARs
 			function (next) {
-				async.each(aarFiles, function (file, cb) {
+				async.eachSeries(aarFiles, function (file, cb) {
 					handleAAR(file, function (err, foundJars) {
 						if (err) {
 							return cb(err);


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24539

During .aar handling any contained assets are copied to the build/android/assets folder. This was done in parallel causing multiple I/O operations happen on the same directory at once which sometimes lead to unexpected behavior. Running the .aar handling in series fixes this problem.