### PR TITLE
[TIMOB-24829] Android: Use incremental tasks for Hyperloop build steps

### DIFF
--- a/android/plugins/hyperloop/hooks/android/internal/monitor/change-manager.js
+++ b/android/plugins/hyperloop/hooks/android/internal/monitor/change-manager.js
@@ -1,0 +1,78 @@
+const fs = require('fs-extra');
+const FileStateMonitor = require('./file-state-monitor');
+const path = require('path');
+
+const INPUTS_STATE_FILENAME = 'inputs.state';
+const OUTPUTS_STATE_FILENAME = 'outputs.state';
+
+/**
+ * Manages the state for a set of input and output files usin a file monitor
+ */
+class ChangeManager {
+
+	/**
+	 * Constructs a new change manager
+	 */
+	constructor() {
+		this._inputs = new FileStateMonitor();
+		this._outputs = new FileStateMonitor();
+	}
+
+	/**
+	 * Loads the existing state data from the given path
+	 *
+	 * @param {string} statePath Full path to the directory containing state data
+	 * @return {boolean} Wether the loading was successful or not
+	 */
+	load(statePath) {
+		let inputsStatePathAndFilename = path.join(statePath, INPUTS_STATE_FILENAME);
+		let outputsStatePathAndFilename = path.join(statePath, OUTPUTS_STATE_FILENAME);
+		if (!fs.existsSync(inputsStatePathAndFilename) || !fs.existsSync(outputsStatePathAndFilename)) {
+			return false;
+		}
+		return this._inputs.load(inputsStatePathAndFilename) && this._outputs.load(outputsStatePathAndFilename);
+	}
+
+	/**
+	 * Writes the current state data into state files in the given path
+	 *
+	 * @param {string} statePath Full path to the directory where the state data should be storeds
+	 */
+	write(statePath) {
+		fs.ensureDirSync(statePath);
+
+		this._inputs.write(path.join(statePath, INPUTS_STATE_FILENAME));
+		this._outputs.write(path.join(statePath, OUTPUTS_STATE_FILENAME));
+	}
+
+	delete(statePath) {
+		fs.emptyDirSync(statePath);
+	}
+
+	monitorInputPath(pathToMonitor) {
+		this._inputs.monitorPath(pathToMonitor);
+	}
+
+	monitorOutputPath(pathToMonitor) {
+		this._outputs.monitorPath(pathToMonitor);
+	}
+
+	hasChanges() {
+		return this.getChangedInputFiles().size > 0 || this.getChangedOutputFiles().size > 0;
+	}
+
+	getChangedInputFiles() {
+		return this._inputs.getChangedFiles();
+	}
+
+	getChangedOutputFiles() {
+		return this._outputs.getChangedFiles();
+	}
+
+	updateOutputFiles(paths) {
+		this._outputs.update(paths);
+	}
+
+}
+
+module.exports = ChangeManager;

--- a/android/plugins/hyperloop/hooks/android/internal/monitor/file-state-monitor.js
+++ b/android/plugins/hyperloop/hooks/android/internal/monitor/file-state-monitor.js
@@ -1,0 +1,158 @@
+const fs = require('fs-extra');
+const FileState = require('./file-state');
+const path = require('path');
+
+const FILE_STATE_NEW = 'new';
+const FILE_STATE_CHANGED = 'changed';
+const FILE_STATE_REMOVED = 'removed';
+
+/**
+ * State monitor for a set of files
+ */
+class FileStateMonitor {
+
+	/**
+	 * Constrcuts a new FileStateManager
+	 */
+	constructor() {
+		/**
+		 * Map of the initially loaded files from the state file
+		 *
+		 * @type {Map}
+		 */
+		this._loadedFiles = new Map();
+
+		/**
+		 * Map containing processed files
+		 *
+		 * @type {Map}
+		 */
+		this._processedFiles = new Map();
+
+		/**
+		 * Map with state of changed files
+		 *
+		 * @type {Map}
+		 */
+		this._changedFiles = new Map();
+	}
+
+	/**
+	 * Loads cached file state information from a state file
+	 *
+	 * @param {string} statePathAndFilename Full path to the state file
+	 * @return {boolean} True if the state file was loaded successfully, false otherwise
+	 */
+	load(statePathAndFilename) {
+		if (!fs.existsSync(statePathAndFilename)) {
+			return false;
+		}
+
+		try {
+			let stateJson = JSON.parse(fs.readFileSync(statePathAndFilename).toString());
+			stateJson.files.forEach(stateEntry => {
+				let fileState = new FileState(stateEntry.path, stateEntry.lastModified, stateEntry.size, stateEntry.sha1);
+				this._loadedFiles.set(fileState.path, fileState);
+			});
+
+			return true;
+		} catch (e) {
+			// shouldn't happen,
+		}
+
+		return false;
+	}
+
+	/**
+	 * Write the current file states back to disk
+	 *
+	 * @param {string} statePathAndFilename Fill path to the state file
+	 */
+	write(statePathAndFilename) {
+		let stateData = {
+			files: []
+		};
+		for (let fileState of this._processedFiles.values()) {
+			stateData.files.push({
+				path: fileState.path,
+				lastModified: fileState.lastModified,
+				size: fileState.size,
+				sha1: fileState.sha1
+			});
+		}
+		fs.ensureDirSync(path.dirname(statePathAndFilename));
+		fs.writeFileSync(statePathAndFilename, JSON.stringify(stateData));
+	}
+
+	/**
+	 * Monitor a new file or directory with this state monitor
+	 *
+	 * @param {string} pathToMonitor Full path of the file or directory to be monitored
+	 */
+	monitorPath(pathToMonitor) {
+		if (!fs.existsSync(pathToMonitor)) {
+			// ignore non-existing paths
+			return;
+		}
+
+		let stats = fs.lstatSync(pathToMonitor);
+		if (stats.isFile()) {
+			this.updateFileState(pathToMonitor);
+		} else if (stats.isDirectory()) {
+			fs.readdirSync(pathToMonitor).forEach(entryName => {
+				let fullPath = path.join(pathToMonitor, entryName);
+				this.monitorPath(fullPath);
+			});
+		}
+	}
+
+	/**
+	 * Detects changes to the file and updates its state
+	 *
+	 * If the file did not exists in our loaded state before, add it as a new one.
+	 * For existing files check wether they have changed and update the file states
+	 * map and move them from the loaded map to processed.
+	 *
+	 * @param {[type]} pathAndFilename [description]
+	 * @return {[type]} [description]
+	 */
+	updateFileState(pathAndFilename) {
+		let newFileState = new FileState(pathAndFilename);
+		let existingFileState = this._loadedFiles.get(pathAndFilename);
+		if (existingFileState === undefined) {
+			this._changedFiles.set(pathAndFilename, FILE_STATE_NEW);
+			this._processedFiles.set(pathAndFilename, newFileState);
+		} else {
+			this._loadedFiles.delete(pathAndFilename);
+			if (newFileState.isDifferentThan(existingFileState)) {
+				this._changedFiles.set(pathAndFilename, FILE_STATE_CHANGED);
+				this._processedFiles.set(pathAndFilename, newFileState);
+			} else {
+				this._processedFiles.set(pathAndFilename, existingFileState);
+			}
+		}
+	}
+
+	update(paths) {
+		this._loadedFiles.clear();
+		this._processedFiles.forEach((fileState, path) => {
+			this._loadedFiles.set(path, fileState);
+		});
+		this._processedFiles.clear();
+		this._changedFiles.clear();
+		paths.forEach(path => {
+			this.monitorPath(path);
+		});
+	}
+
+	getChangedFiles() {
+		let changedFiles = new Map(this._changedFiles);
+		for (let removedFile of this._loadedFiles.values()) {
+			changedFiles.set(removedFile.path, FILE_STATE_REMOVED);
+		}
+		return changedFiles;
+	}
+
+}
+
+module.exports = FileStateMonitor;

--- a/android/plugins/hyperloop/hooks/android/internal/monitor/file-state.js
+++ b/android/plugins/hyperloop/hooks/android/internal/monitor/file-state.js
@@ -1,0 +1,108 @@
+const crypto = require('crypto');
+const fs = require('fs');
+
+/**
+ * Represents the current state of a file
+ */
+class FileState {
+
+  /**
+   * Constructs a new file state
+   *
+   * If only the path is given, the other parameters will be automatically
+   * computed.
+   *
+   * @param {string} path Full path to the file
+   * @param {Number} lastModified Last modification time of the file
+   * @param {Number} size File size in bytes
+   * @param {string} sha1 SHA-1 hash of the file
+   */
+  constructor(path, lastModified, size, sha1) {
+    this._path = path;
+    if (arguments.length > 1) {
+      this._lastModified = lastModified;
+      this._size = size;
+      this._sha1 = sha1;
+    } else {
+      let stat = fs.statSync(path);
+      this._lastModified = stat.mtime.getTime();
+      this._size = stat.size;
+      this._sha1 = null;
+    }
+  }
+
+  /**
+   * Gets the path of the file
+   *
+   * @return {string} Full file path
+   */
+  get path() {
+    return this._path;
+  }
+
+  /**
+   * Gets the last modification date of the file
+   *
+   * @return {Number} Last modified date in miliseconds
+   */
+  get lastModified() {
+    return this._lastModified;
+  }
+
+  /**
+   * Gets the file size of the file
+   *
+   * @return {Number} File size in bytes
+   */
+  get size() {
+    return this._size;
+  }
+
+  /**
+   * Gets the SHA-1 hash of the file's content
+   *
+   * @return {string} SHA-1 content hash
+   */
+  get sha1() {
+    if (this._sha1 === null) {
+      this._sha1 = this.computeSha1();
+    }
+    return this._sha1;
+  }
+
+  /**
+   * Computes the sha1 hash of the files content
+   *
+   * @return {string} Computed sha1 hash
+   */
+  computeSha1() {
+    let hash = crypto.createHash('sha1');
+    hash.update(fs.readFileSync(this._path))
+    return hash.digest('hex');
+  }
+
+  /**
+   * Checks if this file state is different than another given file state
+   *
+   * We do the checks in order of fastest to slowest. First check the
+   * modification times, then for different file size and last one is SHA-1
+   * content hash.
+   *
+   * @param {FileState} otherState File state to check against
+   * @return {Boolean} True if the two file states are different, false otherwise
+   */
+  isDifferentThan(otherState) {
+    if (this.path !== otherState.path) {
+      throw new Error(`Can only compare files with the same path, but tried to compare ${this._path} with ${otherState.path}`);
+    }
+
+    if (this.lastModified === otherState.lastModified) {
+      return false;
+    }
+
+    return this.size !== otherState.size || this.sha1 !== otherState.sha1;
+  }
+
+}
+
+module.exports = FileState;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/base-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/base-task.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Defines the base interface for all other tasks
+ */
+class BaseTask {
+
+	constructor(taskInfo) {
+		this._name = taskInfo.name;
+		this._inputFiles = taskInfo.inputFiles || [];
+		this._outputFiles = taskInfo.outputFiles || []; // Do we even need this?
+		this._outputDirectory = taskInfo.outputDirectory;
+		this._logger = taskInfo.logger;
+	}
+
+	get name() {
+		return this._name;
+	}
+
+	get inputFiles() {
+		return this._inputFiles;
+	}
+
+	get outputFiles() {
+		return this._outputFiles;
+	}
+
+	get outputDirectory() {
+		return this._outputDirectory;
+	}
+
+	get logger() {
+		return this._logger;
+	}
+
+	/**
+	 * Sets the output directory and adds all files under the given path to this
+	 * task's output files
+	 *
+	 * Setting this will reset all existing output files
+	 *
+	 * @param {string} outputPath Full path of the directory to add
+	 */
+	set outputDirectory(outputPath) {
+		if (!fs.existsSync(outputPath)) {
+			fs.ensureDirSync(outputPath);
+		}
+
+		this._outputFiles = [];
+		this._outputDirectory = outputPath;
+		fs.readdirSync(name => {
+			let fullPath = path.join(outputPath, name);
+			let stats = fs.lstatSync(fullPath);
+			if (stats.isDirectory()) {
+				this.addOutputDirectory(fullPath);
+			} else if (stats.isFile()) {
+				this.addOutputFile(fullPath);
+			}
+		});
+	}
+
+	/**
+	 * Adds a new file to this task's input files
+	 *
+	 * @param {string} pathAndFilename Full path of the file to add
+	 */
+	addInputFile(pathAndFilename) {
+		if (!fs.existsSync(pathAndFilename)) {
+			throw new Error('Input file ' + pathAndFilename + ' does not exists');
+		}
+
+		if (this.inputFiles.indexOf(pathAndFilename) === -1) {
+			this.inputFiles.push(pathAndFilename);
+		}
+	}
+
+	/**
+	 * Adds all files under the given path to this task's input files
+	 *
+	 * @param {string} inputPath Full path of the directory to add
+	 */
+	addInputDirectory(inputPath) {
+		if (!fs.existsSync()) {
+			return;
+		}
+
+		fs.readdirSync(name => {
+			let fullPath = path.join(inputPath, name);
+			let stats = fs.lstatSync(fullPath);
+			if (stats.isDirectory()) {
+				this.addInputDirectory(fullPath);
+			} else if (stats.isFile()) {
+				this.addInputFile(fullPath);
+			}
+		});
+	}
+
+	/**
+	 * Adds a new file to this task's output files
+	 *
+	 * @param {string} pathAndFilename Full path of the file to add
+	 */
+	addOutputFile(pathAndFilename) {
+		if (!fs.existsSync(pathAndFilename)) {
+			throw new Error('Output file ' + pathAndFilename + ' does not exists');
+		}
+
+		if (this.outputFiles.indexOf(pathAndFilename) === -1) {
+			this.outputFiles.push(pathAndFilename);
+		}
+	}
+
+	run() {
+		this.logger.trace(this.name + ': Starting task run');
+		const startTime = process.hrtime();
+
+		if (typeof this.preTaskRun === 'function') {
+			this.logger.trace(this.name + ': Running pre task run function');
+			this.preTaskRun();
+		}
+		return this.runTaskAction().then(taskResult => {
+			if (typeof this.postTaskRun === 'function') {
+				this.logger.trace(this.name + ': Running post task run function');
+				this.postTaskRun();
+			}
+
+			const elapsedTIme = process.hrtime(startTime);
+			this.logger.trace(this.name + ': Finished task in ' + this.formatElapsedTime(elapsedTIme));
+
+			return taskResult;
+		});
+	}
+
+
+	runTaskAction() {
+		throw new Error('No task action implemented, override runTaskAction');
+	}
+
+	formatElapsedTime(elapsedTime) {
+		let precision = 3;
+		var elapsedMilliseconds = elapsedTime[1] / 1000000;
+		return elapsedTime[0] + 's ' + elapsedMilliseconds.toFixed(precision) + ' ms';
+	}
+
+}
+
+module.exports = BaseTask;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/copy-sources-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/copy-sources-task.js
@@ -1,0 +1,85 @@
+const fs = require('fs-extra');
+const IncrementalTask = require('./incremental-task');
+const path = require('path');
+
+/**
+ * Task to copy all generated Hyperloop wrappers into the app's Resources
+ * directory
+ *
+ * TODO: Include minification here? Or move it to own incremental task so we
+ * don't have to do it over and over agin?
+ *
+ * @type {[type]}
+ */
+class CopySourcesTask extends IncrementalTask {
+
+	constructor(taskInfo) {
+		super(taskInfo);
+
+		this.inputDirectory = taskInfo.inputDirectory;
+		//this.minifyJs = taskInfo.minifyJs;
+	}
+
+	get incrementalOutputs() {
+		return [this.outputDirectory];
+	}
+
+	/**
+	 * Does full task run, wich will empty the output directory and copy all
+	 * available wrappers into it
+	 *
+	 * @return {Promise}
+	 */
+	doFullTaskRun() {
+		fs.emptyDirSync(this.outputDirectory);
+
+		return new Promise((resolve, reject) => {
+			fs.copy(this.inputDirectory, this.outputDirectory, err => {
+				if (err) {
+					reject(err);
+				}
+
+				resolve();
+			});
+		});
+	}
+
+	/**
+	 * Does an incremental task run, which will sync the output directory based
+	 * on the changed input file states
+	 *
+	 * @param {Map} changedFiles Map of changed files and their state (new, changed, removed)
+	 * @return {Promise}
+	 */
+	doIncrementalTaskRun(changedFiles) {
+		let syncPromises = [];
+		changedFiles.forEach((state, pathAndFilename) => {
+			let promise = new Promise((resolve, reject) => {
+				let destinationPathAndFilename = path.join(this.outputDirectory, path.basename(pathAndFilename));
+				if (state === 'new' || state === 'changed') {
+					fs.copy(pathAndFilename, destinationPathAndFilename, err => {
+						if (err) {
+							reject(err);
+						}
+
+						resolve();
+					});
+				} else if (state === 'removed') {
+					fs.remove(destinationPathAndFilename, err => {
+						if (err) {
+							reject(err);
+						}
+
+						resolve();
+					});
+				}
+			});
+			syncPromises.push(promise);
+		});
+
+		return Promise.all(syncPromises);
+	}
+
+}
+
+module.exports = CopySourcesTask;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/generate-metabase-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/generate-metabase-task.js
@@ -1,0 +1,47 @@
+const BaseTask = require('./base-task');
+const metabase = require('../../metabase');
+
+/**
+ * A task that will generate the Android metabase
+ *
+ * This is implemented as a simple base task because the metabase generation
+ * itself has a caching machanisim, so we just delegate and return the result.
+ */
+class GenerateMetabaseTask extends BaseTask {
+
+	constructor(taskInfo) {
+		super(taskInfo);
+
+		this._builder = null;
+	}
+
+	/**
+	 * Sets the AndroidBuilder instance
+	 *
+	 * @param {AndroidBuilder} builder
+	 */
+	set builder(builder) {
+		this._builder = builder;
+	}
+
+	/**
+	 * Starts the metabase generation by delegating to the existing metabase loader
+	 *
+	 * @return {Promise}
+	 */
+	runTaskAction() {
+		this.logger.trace(this.name + ': Generating metabase for JARs: ' + this.inputFiles);
+		return new Promise((resolve, reject) => {
+			metabase.metabase.loadMetabase(this.inputFiles, {platform: 'android-' + this._builder.realTargetSDK}, (err, json) => {
+				if (err) {
+					this.logger.error(this.name + ': Failed to generated metabase: ' + err);
+					return reject(err);
+				}
+				resolve(json);
+			});
+		});
+	}
+
+}
+
+module.exports = GenerateMetabaseTask;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/generate-sources-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/generate-sources-task.js
@@ -1,0 +1,206 @@
+const fs = require('fs-extra');
+const IncrementalTask = require('./incremental-task');
+const metabase = require('../../metabase');
+const path = require('path');
+
+/**
+ * Generates Hyperloop wrapper files for all Java classes being referenced
+ */
+class GenerateSourcesTask extends IncrementalTask {
+
+	constructor(taskInfo) {
+		super(taskInfo);
+
+		this._metabase = null;
+		this._references = null;
+		this._classListPathAndFilename = path.join(this.incrementalDirectory, 'classes.json');
+		this._generatedClasses = [];
+	}
+
+	/**
+	 * Metabase that will be used to genrate the warpper files
+	 *
+	 * @return {Object} Metabase object
+	 */
+	get metabase() {
+		return this._metabase;
+	}
+
+	/**
+	 * Sets the metabase object
+	 *
+	 * @param {Object} metabase
+	 */
+	set metabase(metabase) {
+		this._metabase = metabase;
+	}
+
+	/**
+	 * Mapping of source files and their referenced Java types
+	 *
+	 * @return {Map}
+	 */
+	get references() {
+		return this._references;
+	}
+
+	/**
+	 * Sets the Java type reference map
+	 *
+	 * @param {Map} references
+	 */
+	set references(references) {
+		this._references = references;
+	}
+
+	get incrementalOutputs() {
+		return [this.outputDirectory, this._classListPathAndFilename];
+	}
+
+	/**
+	 * Does full task run, wich will generate the Hyperloop wrapper for every
+	 * referencced Java class
+	 *
+	 * @return {Promise}
+	 */
+	doFullTaskRun() {
+		fs.emptyDirSync(this.outputDirectory);
+
+		if (this.references.size === 0) {
+			this._logger.info('Skipping Hyperloop wrapper generation, no usage found ...');
+			return Promise.resolve();
+		}
+
+		let classesToGenerate = [];
+		this.references.forEach(fileInfo => {
+			fileInfo.usedClasses.forEach(className => {
+				if (classesToGenerate.indexOf(className) === -1) {
+					classesToGenerate.push(className);
+				}
+			});
+		});
+
+		return this.generateSources(classesToGenerate).then(this.writeClassList.bind(this));
+	}
+
+	/**
+	 * Does an incremental task run, which will generate the Hyperloop wrappers
+	 * for new and changed files and delete the wrapper for removed references.
+	 *
+	 * To properly detect removed references we store a list with the name of all
+	 * generated wrapper files and compare that with the currently referenced ones.
+	 * Any wrapper file that is not referenced anymore will be deleted.
+	 *
+	 * @param {Map} changedFiles Map of changed files and their state (new, changed, removed)
+	 * @return {Promise}
+	 */
+	doIncrementalTaskRun(changedFiles) {
+		let fullBuild = !this.loadClassList();
+		if (fullBuild) {
+			return this.doFullTaskRun();
+		}
+
+		let classesToGenerate = [];
+		let referencedClasses = [];
+
+		this.references.forEach((fileInfo, pathAndFilename) => {
+			fileInfo.usedClasses.forEach(className => {
+				if (referencedClasses.indexOf(className) === -1) {
+					referencedClasses.push(className);
+				}
+			});
+
+			var fileState = changedFiles.get(pathAndFilename);
+			if (fileState === undefined) {
+				return;
+			}
+			if (fileState === 'new' || fileState === 'changed') {
+				this.references[pathAndFilename].usedClasses.forEach(className => {
+					if (this._generatedClasses.indexOf(className) !== -1) {
+						return;
+					}
+
+					if (classesToGenerate.indexOf(className) === -1) {
+						classesToGenerate.push(this.references[pathAndFilename].usedClasses);
+					}
+				});
+			}
+		});
+
+		this._generatedClasses = this._generatedClasses.filter(className => {
+			if (referencedClasses.indexOf(className) === -1) {
+				let wrapperPathAndFilename = path.join(this.outputDirectory, className + '.js');
+				if (fs.existsSync(wrapperPathAndFilename)) {
+					fs.unlinkSync(wrapperPathAndFilename);
+				}
+				return false;
+			}
+			return true;
+		});
+
+		return this.generateSources(classesToGenerate).then(this.writeClassList.bind(this));
+	}
+
+	/**
+	 * Generates the wrapper source files by delegating to the generator inside
+	 * the metabase module
+	 *
+	 * @param {Array} classes List of classes to generate the sources for
+	 * @return {Promise}
+	 */
+	generateSources(classes) {
+		if (classes.length === 0) {
+			return Promise.resolve();
+		}
+
+		return new Promise((resolve, reject) => {
+			metabase.generate.generateFromJSON(this.outputDirectory, this.metabase, classes, (err) => {
+				if (err) {
+					reject(err);
+				}
+
+				this._generatedClasses = this._generatedClasses.concat(classes);
+
+				resolve();
+			});
+		});
+	}
+
+	/**
+	 * Loads the class list used in incremental task runs
+	 *
+	 * @return {boolean} True if the files was loaded succesfully, false otherwise
+	 */
+	loadClassList() {
+		if (!fs.existsSync(this._classListPathAndFilename)) {
+			return false;
+		}
+
+		try {
+			this._generatedClasses = JSON.parse(fs.readFileSync(this._classListPathAndFilename));
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Stores the list of all currently generated Hyperloop class wrappers
+	 *
+	 * @return {Promise}
+	 */
+	writeClassList() {
+		return new Promise((resolve, reject) => {
+			fs.writeFile(this._classListPathAndFilename, JSON.stringify(this._generatedClasses), (err) => {
+				if (err) {
+					reject(err);
+				}
+
+				resolve();
+			});
+		});
+	}
+
+}
+
+module.exports = GenerateSourcesTask;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/incremental-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/incremental-task.js
@@ -1,0 +1,116 @@
+const BaseTask = require('./base-task');
+const ChangeManager = require('../monitor/change-manager');
+const fs = require('fs-extra');
+
+/**
+ * Files based task that is aware of the state of its input and output files and
+ * can perform an incremental task run
+ */
+class IncrementalTask extends BaseTask {
+
+	constructor(taskInfo) {
+		super(taskInfo);
+
+		if (!taskInfo.incrementalDirectory) {
+			throw new Error('Incremental tasks need an incrementalDirectory specified');
+		}
+		this._incrementalDirectory = taskInfo.incrementalDirectory;
+		fs.ensureDirSync(this.incrementalDirectory);
+	}
+
+	/**
+	 * Gets the directory where any incremental data will be stored
+	 *
+	 * @return {string} Full path to the incremental data directory
+	 */
+	get incrementalDirectory() {
+		return this._incrementalDirectory;
+	}
+
+	/**
+	 * List of directories or files that this task generates
+	 *
+	 * This is used to determine if the output files of a task were changed
+	 *
+	 * @return {Array}
+	 */
+	get incrementalOutputs() {
+		return [];
+	}
+
+	/**
+	 * Checks for changed states of input and output files and starts either a full
+	 * or incremental task run
+	 *
+	 * The rules for this are as follows:
+	 *   - No incremental data: full task run
+	 *   - Output files changed: full task run
+	 *   - Input files changed: incremental task run
+	 *   - Nothing changed: skip task run
+	 *
+	 * @return {Promise}
+	 */
+	runTaskAction() {
+		let changeManager = new ChangeManager();
+		let fullBuild = !changeManager.load(this.incrementalDirectory);
+
+		this.inputFiles.forEach(inputPath => {
+			changeManager.monitorInputPath(inputPath);
+		});
+
+		this.incrementalOutputs.forEach(outputPath => {
+			changeManager.monitorOutputPath(outputPath);
+		});
+
+		let changedInputFiles = changeManager.getChangedInputFiles();
+		let changedOutputFiles = changeManager.getChangedOutputFiles();
+		let runPromise;
+		if (fullBuild) {
+			this._logger.trace(this.name + ': No incremental data, do full task run');
+			runPromise = this.doFullTaskRun();
+		} else if (changedOutputFiles.size > 0) {
+			this._logger.trace(this.name + ': Output files changed, do full task run');
+			runPromise = this.doFullTaskRun();
+		} else if (changedInputFiles.size > 0) {
+			this._logger.trace(this.name + ': Input files changed, do incremental task run');
+			runPromise = this.doIncrementalTaskRun(changedInputFiles);
+		} else {
+			this._logger.trace(this.name + ': Nothing changed, skip task run');
+			runPromise = this.loadResultAndSkip();
+		}
+
+		return runPromise.then(taskResult => {
+			changeManager.updateOutputFiles(this.incrementalOutputs);
+			changeManager.write(this.incrementalDirectory);
+
+			return taskResult;
+		}).catch((reason) => {
+			changeManager.delete(this.incrementalDirectory);
+			throw new Error(reason);
+		});
+	}
+
+	doFullTaskRun() {
+		throw new Error('No full task action implemented, override doFullTaskRun');
+	}
+
+	doIncrementalTaskRun() {
+		throw new Error('No incremental task action implemented, override doIncrementalTaskRun');
+	}
+
+	/**
+	 * Loads the result of the last task run and skips it
+	 *
+	 * If no input or output files changed a task will be skiped. Override this if
+	 * the task needs to return some JS value after completion. By default a task
+	 * has no return value.
+	 *
+	 * @return {Promise}
+	 */
+	loadResultAndSkip() {
+		return Promise.resolve();
+	}
+
+}
+
+module.exports = IncrementalTask;

--- a/android/plugins/hyperloop/hooks/android/internal/tasks/scan-references-task.js
+++ b/android/plugins/hyperloop/hooks/android/internal/tasks/scan-references-task.js
@@ -1,0 +1,248 @@
+const fs =  require('fs-extra');
+const IncrementalTask = require('./incremental-task');
+const path = require('path');
+
+const REFERENCES_FILENAME = 'references.json';
+
+/**
+ * Scans JavaScript files for any references to Hyperloop wrappers by checking
+ * any requires against our available classes in the metabase.
+ *
+ * This references are used so we know what wrappers to generate. In addition
+ * this will replace the requires from their Java class name to their actual
+ * Hyperloop wrapper file and save that new file content so we can reuse it
+ * on incremental builds.
+ */
+class ScanReferencesTask extends IncrementalTask {
+
+	constructor(taskInfo) {
+		super(taskInfo);
+
+		this._outputDirectory = taskInfo.outputDirectory;
+		this._referencesPathAndFilename = path.join(this._outputDirectory, REFERENCES_FILENAME);
+		this._references = new Map();
+		this._metabase = null;
+	}
+
+	/**
+	 * Gets the metabase data used to check if a require refers to an existing
+	 * Java type
+	 *
+	 * @return {Object}
+	 */
+	get metabase() {
+		return this._metabase;
+	}
+
+	/**
+	 * Sets the metabase data
+	 *
+	 * @param {Object} metabase Metabase object
+	 */
+	set metabase(metabase) {
+		this._metabase = metabase;
+	}
+
+	get incrementalOutputs() {
+		return [this.outputDirectory];
+	}
+
+	/**
+	 * Does a full task run, which scans all input files for Hyperloop related
+	 * require statements
+	 *
+	 * @return {Promise}
+	 */
+	doFullTaskRun() {
+		fs.emptyDirSync(this.outputDirectory);
+		this.inputFiles.forEach(pathAndFilename => {
+			this.scanFileForHyperloopRequires(pathAndFilename);
+		});
+		this.writeReferences();
+
+		return Promise.resolve(this._references);
+	}
+
+	/**
+	 * Does an incremental task run, which only scans the changed files for any
+	 * Hyperloop related require statements and updates the reference map. Also
+	 * removes any references from files that were deleted.
+	 *
+	 * @param {Map} changedFiles Map of changed files and their state (new, changed, removed)
+	 * @return {Promise}
+	 */
+	doIncrementalTaskRun(changedFiles) {
+		let fullBuild = !this.loadReferences();
+		if (fullBuild) {
+			return this.doFullTaskRun();
+		}
+
+		changedFiles.forEach((state, pathAndFilename) => {
+			if (state === 'new' || state === 'changed') {
+				let hyperloopUsed = this.scanFileForHyperloopRequires(pathAndFilename);
+				if (!hyperloopUsed) {
+					this._references.delete(pathAndFilename);
+				}
+			} else if (state === 'removed') {
+				this._references.delete(pathAndFilename);
+			}
+		});
+		this.writeReferences();
+
+		return Promise.resolve(this._references);
+	}
+
+	/**
+	 * If nothing changed load the existing references from file and return them
+	 *
+	 * @return {Promise}
+	 */
+	loadResultAndSkip() {
+		let loaded = this.loadReferences();
+		if (loaded) {
+			return Promise.resolve(this._references);
+		} else {
+			return this.doFullTaskRun();
+		}
+	}
+
+	/**
+	 * Loads references of the last build from file.
+	 *
+	 * @return {boolean} True if the reference file was succesfully loaded, otherwise false
+	 */
+	loadReferences() {
+		if (!fs.existsSync(this._referencesPathAndFilename)) {
+			return false;
+		}
+
+		try {
+			let referencesObj = JSON.parse(fs.readFileSync(this._referencesPathAndFilename));
+			this._references = new Map();
+			Object.keys(referencesObj).forEach(pathAndFilename => {
+				this._references.set(pathAndFilename, referencesObj[pathAndFilename]);
+			});
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Writes the references to file
+	 */
+	writeReferences() {
+		let referencesObj = {};
+		this._references.forEach((fileInfo, pathAndFilename) => {
+			referencesObj[pathAndFilename] = fileInfo;
+		});
+		let referencesJson = JSON.stringify(referencesObj);
+		fs.ensureDirSync(path.dirname(this._referencesPathAndFilename));
+		fs.writeFileSync(this._referencesPathAndFilename, referencesJson);
+	}
+
+	/**
+	 * Scans a file for any requires to Java types, records
+	 * @param {[type]} pathAndFilename [description]
+	 * @return {[type]} [description]
+	 */
+	scanFileForHyperloopRequires(pathAndFilename) {
+		var result = this.extractAndReplaceHyperloopRequires(pathAndFilename);
+		if (result !== null && result.usedClasses.length > 0) {
+			this._references.set(pathAndFilename, {
+				usedClasses: result.usedClasses,
+				replacedContent: result.replacedContent
+			});
+			return true;
+		}
+
+		return false;
+	}
+
+	extractAndReplaceHyperloopRequires(file) {
+		if (!fs.existsSync(file)) {
+			return null;
+		}
+
+		var contents = fs.readFileSync(file, 'UTF-8'),
+			usedClasses = [],
+			requireRegex = /require\s*\(\s*[\\"']+([\w_\/-\\.\\*]+)[\\"']+\s*\)/ig;
+		this._logger.trace('Searching for hyperloop requires in: ' + file);
+		(contents.match(requireRegex) || []).forEach(m => {
+			var re = /require\s*\(\s*[\\"']+([\w_\/-\\.\\*]+)[\\"']+\s*\)/i.exec(m),
+				className = re[1],
+				lastIndex,
+				validPackage = false,
+				type,
+				ref,
+				str,
+				packageRegexp = new RegExp('^' + className.replace('.', '\\.').replace('*', '[A-Z]+[a-zA-Z0-9]+') + '$');
+
+			// Is this a Java type we found in the JARs/APIs?
+			this._logger.trace('Checking require for: ' + className);
+
+			// Look for requires using wildcard package names and assume all types under that namespace!
+			if (className.indexOf('.*') == className.length - 2) {
+				// Check that it's a valid package name and search for all the classes directly under that package!
+				for (var mClass in this.metabase.classes) {
+					if (mClass.match(packageRegexp)) {
+						usedClasses.push(mClass);
+						validPackage = true;
+					}
+				}
+				if (validPackage) {
+					ref = 'hyperloop/' + className.slice(0, className.length - 2); // drop the .* ending
+					str = 'require(\'' + ref + '\')';
+					contents = this.replaceAll(contents, m, str);
+				}
+			} else {
+				// single type
+				type = this.metabase.classes[className];
+				if (!type) {
+					// fallback for using dot notation to refer to nested class
+					lastIndex = className.lastIndexOf('.');
+					className = className.slice(0, lastIndex) + '$' + className.slice(lastIndex + 1);
+					type = this.metabase.classes[className];
+					if (!type) {
+						return;
+					}
+				}
+				// Looks like it's a Java type, so let's hack it and add it to our list!
+				// replace the require to point to our generated file path
+				ref = 'hyperloop/' + className;
+				str = 'require(\'' + ref + '\')';
+				contents = this.replaceAll(contents, m, str);
+				usedClasses.push(className);
+			}
+		});
+		return {
+			usedClasses: usedClasses,
+			replacedContent: contents
+		};
+	}
+
+	/**
+	 * Replaces all occurrences of needle in haystack
+	 *
+	 * @param {[type]} haystack [description]
+	 * @param {[type]} needle [description]
+	 * @param {[type]} replaceStr [description]
+	 * @return {[type]} [description]
+	 */
+	replaceAll(haystack, needle, replaceStr) {
+		var newBuffer = haystack;
+		while (1) {
+			var index = newBuffer.indexOf(needle);
+			if (index < 0) {
+				break;
+			}
+			var before = newBuffer.substring(0, index),
+				after = newBuffer.substring(index + needle.length);
+			newBuffer = before + replaceStr + after;
+		}
+		return newBuffer;
+	}
+
+}
+
+module.exports = ScanReferencesTask;

--- a/android/plugins/hyperloop/hooks/android/metabase/generate.js
+++ b/android/plugins/hyperloop/hooks/android/metabase/generate.js
@@ -200,7 +200,7 @@ function generateFromJSON(dir, metabaseJSON, classes, callback) {
 		// Generate package entries all the way up!
 		for (var i = 0; i < packageParts.length - 1; i++) {
 			var tmpPackageName = packageParts.slice(0, i + 1).join('.');
-			packages[tmpPackageName] = packages[tmpPackageName] || {};
+			packages[tmpPackageName] = packages[tmpPackageName] || [];
 		}
 
 		json.name = className;


### PR DESCRIPTION
This is something i hacked together over the last days and should be treated more of a feature proposal than an actual pull request. Since the whole Android build pipeline currently has little to no caching of its different build steps, i tried to implement an incremental task approach to speed up the Android Hyperloop plugin.

The task and change detection stuff is heavily inspired by Gradle because i think they did a pretty neat job there, so i adopted it to the async nature of Node and simplified everything a little bit. Maybe this can even be integrated in the daemon in the feature by using the fs-watcher stuff from there and use the task system for implementing our build pipelines as plugins.

To sum this up:

- Created a file monitor that is able to work between builds by storing its state in a file. This is the main difference to other available file watchers for node
- Created a simple task structure which uses the file monitoring to support incremental task runs
- Took the different build steps and refactored them into single tasks that are run after each other. They all have defined input and output files on which they work on and those are used to check if we can do an incremental task run.
- Huge improvement on testability: We can easily unit test single tasks. The Android build itself as well as the Hyperloop plugin currently do not have not a single unit.

Obviously this is not complete yet (missing unit tests for the base tasks, move the file monitor and base tasks to their own module), but i would love to hear some thoughts on this. I had to write so many manual caching logic around builds steps in the Android Builder and in Hyperloop lately that i thought this might be a great thing to have. This is also a good example to see how easy it is to integrate into our existing build pipeline.