### PR TITLE
[TIMOB-24151] Android: Properly initialize package array

### DIFF
--- a/android/plugins/hyperloop/hooks/android/metabase/generate.js
+++ b/android/plugins/hyperloop/hooks/android/metabase/generate.js
@@ -200,7 +200,7 @@ function generateFromJSON(dir, metabaseJSON, classes, callback) {
 		// Generate package entries all the way up!
 		for (var i = 0; i < packageParts.length - 1; i++) {
 			var tmpPackageName = packageParts.slice(0, i + 1).join('.');
-			packages[tmpPackageName] = packages[tmpPackageName] || {};
+			packages[tmpPackageName] = packages[tmpPackageName] || [];
 		}
 
 		json.name = className;


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24151

The package array was initialized as an object by mistake which caused the issue when trying to add more classes to it.