### PR TITLE
[TIMOB-24945] Pass linker flags to the app project only

### DIFF
--- a/iphone/module.xcconfig
+++ b/iphone/module.xcconfig
@@ -6,21 +6,4 @@
 // for this file:
 // http://help.apple.com/xcode/mac/8.3/#/dev745c5c974
 
-//
-// How to add a Framework (example)
-//
-// OTHER_LDFLAGS=$(inherited) -framework Foo
-//
-// Adding a framework for a specific version(s) of iPhone:
-//
-// OTHER_LDFLAGS[sdk=iphoneos4*]=$(inherited) -framework Foo
-// OTHER_LDFLAGS[sdk=iphonesimulator4*]=$(inherited) -framework Foo
-//
-//
-// How to add a compiler define:
-//
-// OTHER_CFLAGS=$(inherited) -DFOO=1
-//
-//
-// IMPORTANT NOTE: always use $(inherited) in your overrides
-//
+OTHER_LDFLAGS=$(inherited) $(HYPERLOOP_LDFLAGS)

--- a/iphone/plugin/hyperloop.js
+++ b/iphone/plugin/hyperloop.js
@@ -1216,6 +1216,12 @@ HyperloopiOSBuilder.prototype.hookXcodebuild = function hookXcodebuild(data) {
 	}
 
 	function addParam(key, value) {
+		if (key === 'OTHER_LDFLAGS') {
+			// Rewrite other linker flags to the special Hyperloop linker flags to
+			// make sure they will only be passed to iPhone device and sim builds
+			key = 'HYPERLOOP_LDFLAGS';
+		}
+
 		for (var i = 0; i < args.length; i++) {
 			if (args[i].indexOf(key + '=') === 0) {
 				// already exists


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-24945

We rewrite any `OTHER_LDFLAGS` coming from Hyperloop to a special env variable that will be used inside the modules.xcconfig to make sure only the app project receives them. This prevents extensions like watchOS from receiving linker flags that are not meant for them.