### PR TITLE
[TIMOB-25192] Evaluating a null value in async crashes app

### DIFF
--- a/windows/src/Hyperloop.cpp
+++ b/windows/src/Hyperloop.cpp
@@ -150,7 +150,7 @@ JSValue HyperloopPromiseCallback::CallAsFunction(const std::vector<JSValue>& js_
 				try {
 					const auto result = AsyncSupport::GetResults(generic_type__, native_object__);
 					const auto ctx = resolve.get_context();
-					const auto object = HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
+					const auto object = result == nullptr ? ctx.CreateNull() : HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
 					const std::vector<JSValue> args = { object };
 					static_cast<JSObject>(resolve)(args, resolve.get_context().get_global_object());
 				} catch (Platform::COMException^ e) {
@@ -170,7 +170,7 @@ JSValue HyperloopPromiseCallback::CallAsFunction(const std::vector<JSValue>& js_
 				try {
 					const auto result = AsyncSupport::GetResults(generic_type__, native_object__);
 					const auto ctx = resolve.get_context();
-					const auto object = HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
+					const auto object = result == nullptr ? ctx.CreateNull() : HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
 					const std::vector<JSValue> args = { object };
 					static_cast<JSObject>(resolve)(args, resolve.get_context().get_global_object());
 				} catch (Platform::COMException^ e) {
@@ -193,7 +193,7 @@ JSValue HyperloopPromiseCallback::CallAsFunction(const std::vector<JSValue>& js_
 				try {
 					const auto result = AsyncSupport::GetResults(generic_type__, native_object__);
 					const auto ctx = resolve.get_context();
-					const auto object = HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
+					const auto object = result == nullptr ? ctx.CreateNull() : HyperloopModule::Convert(ctx, ref new HyperloopInvocation::Instance(result->GetType(), result));
 					const std::vector<JSValue> args = { object };
 					static_cast<JSObject>(resolve)(args, resolve.get_context().get_global_object());
 				} catch (Platform::COMException^ e) {


### PR DESCRIPTION
[TIMOB-25192](https://jira.appcelerator.org/browse/TIMOB-25192)

Evaluating .NET `null` value in async crashes app.

```js
var win = Ti.UI.createWindow({ backgroundColor: 'green' });
var PopupMenu = require('Windows.UI.Popups.PopupMenu');
var UICommand = require('Windows.UI.Popups.UICommand');
var Point = require('Windows.Foundation.Point');

var menu = new PopupMenu();
var alertHiCommand = new UICommand("Hi!");
var alertByeCommend = new UICommand("Bye!");

var commands = menu.Commands;
commands.Add(alertHiCommand);
commands.Add(alertByeCommend);

function popupMenu(e) {
    var p = new Point(e.y, e.x);
    menu.ShowAsync(p).then(function (selectedCommand) {
        if (selectedCommand == null) {
            alert('nothing selected');
        } else {
            alert(selectedCommand.Label);
        }
    }, function (err) { alert(err) });
}

win.addEventListener('click', function (e) {
    popupMenu(e);
});

win.open();
```

Expected: No crash when you click app window (popup appears) and then you should be able to click elsewhere to cancel popup.