### PR TITLE
[TIMOB-25354] Prevent module generation for non-framework sources

### DIFF
--- a/metabase/ios/lib/generate/index.js
+++ b/metabase/ios/lib/generate/index.js
@@ -25,7 +25,8 @@ function makeModule (modules, e, state) {
 				static_variables: {},
 				blocks: [],
 				frameworks: {},
-				state: state
+				state: state,
+				customSource: e.customSource || false
 			};
 		}
 		return modules[e.framework];


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25354

Adds a missing value assignment so this check during module generation actually works: https://github.com/appcelerator/hyperloop.next/blob/master/metabase/ios/lib/generate/module.js#L70