### PR TITLE
[TIMOB-25354] Prevent module generation for non-framework sources (2_2_X)

### DIFF
--- a/metabase/ios/lib/generate/index.js
+++ b/metabase/ios/lib/generate/index.js
@@ -25,7 +25,8 @@ function makeModule (modules, e, state) {
 				static_variables: {},
 				blocks: [],
 				frameworks: {},
-				state: state
+				state: state,
+				customSource: e.customSource || false
 			};
 		}
 		return modules[e.framework];


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25354

2_2_X backport of #216 