### PR TITLE
Pass jar files from platform folder to dexer

### DIFF
--- a/android/plugins/hyperloop/hooks/android/hyperloop.js
+++ b/android/plugins/hyperloop/hooks/android/hyperloop.js
@@ -271,6 +271,9 @@ exports.cliVersion = '>=3.2';
 							.on('file', function (file) {
 								if (path.extname(file) === '.jar') {
 									jarPaths.push(file);
+									// Also add jars to the list of exclusive jars that are only
+									// available to Hyperloop so they get added to the dexer.
+									exclusiveJars.push(file);
 								}
 							})
 							.on('end', done);


### PR DESCRIPTION
This got lost during the refactoring to gather jar files in parallel in #206. 