### PR TITLE
Add missing return statements on async errors

### DIFF
--- a/android/plugins/hyperloop/hooks/android/hyperloop.js
+++ b/android/plugins/hyperloop/hooks/android/hyperloop.js
@@ -240,7 +240,7 @@ exports.cliVersion = '>=3.2';
 							var libDir = path.join(module.modulePath, 'lib');
 							fs.readdir(libDir, function(err, libraryEntries) {
 								if (err) {
-									cb();
+									return cb();
 								}
 
 								libraryEntries.forEach(function(entryName) {
@@ -279,7 +279,7 @@ exports.cliVersion = '>=3.2';
 						async.each(jarPaths, function(jarPathAndFilename, cb) {
 							fs.readFile(jarPathAndFilename, function(err, buffer) {
 								if (err) {
-									cb();
+									return cb();
 								}
 
 								var jarHash = builder.hash(buffer.toString());


### PR DESCRIPTION
Adds two missing return statements to make sure we exit the callback early in case of an error.

Note: I accidentally pushed this fix directly to the 2_2_X branch, so there is only this PR for master.