### PR TITLE
[TIMOB-25341] Recursively parse nested blocks

### DIFF
--- a/metabase/ios/hyperloop-metabase.xcodeproj/project.pbxproj
+++ b/metabase/ios/hyperloop-metabase.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		24F555191BAD1F9200EC7113 /* function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 24F555181BAD1F9200EC7113 /* function.cpp */; };
 		24F5551C1BAD27C800EC7113 /* struct.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 24F5551B1BAD27C800EC7113 /* struct.cpp */; };
 		24F5551F1BAE122500EC7113 /* union.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 24F5551E1BAE122500EC7113 /* union.cpp */; };
+		4A4A4E291F87C359009DE64F /* BlockParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4A4A4E271F87C359009DE64F /* BlockParser.cpp */; };
 		B626CE681B3E79A4000D2988 /* libclang.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B626CE671B3E79A4000D2988 /* libclang.dylib */; };
 /* End PBXBuildFile section */
 
@@ -89,6 +90,8 @@
 		24F5551B1BAD27C800EC7113 /* struct.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = struct.cpp; path = src/struct.cpp; sourceTree = SOURCE_ROOT; };
 		24F5551D1BAE122500EC7113 /* union.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = union.h; path = src/union.h; sourceTree = SOURCE_ROOT; };
 		24F5551E1BAE122500EC7113 /* union.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = union.cpp; path = src/union.cpp; sourceTree = SOURCE_ROOT; };
+		4A4A4E271F87C359009DE64F /* BlockParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BlockParser.cpp; path = src/BlockParser.cpp; sourceTree = SOURCE_ROOT; };
+		4A4A4E281F87C359009DE64F /* BlockParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BlockParser.h; path = src/BlockParser.h; sourceTree = SOURCE_ROOT; };
 		B626CE381B3E77D0000D2988 /* hyperloop-metabase */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "hyperloop-metabase"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B626CE671B3E79A4000D2988 /* libclang.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libclang.dylib; path = Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -171,6 +174,8 @@
 				24F554FA1BAB906700EC7113 /* util.h */,
 				24F554FB1BAB906700EC7113 /* var.cpp */,
 				24F554FC1BAB906700EC7113 /* var.h */,
+				4A4A4E271F87C359009DE64F /* BlockParser.cpp */,
+				4A4A4E281F87C359009DE64F /* BlockParser.h */,
 			);
 			name = src;
 			path = "hyperloop-metabase";
@@ -308,6 +313,7 @@
 				24F5551C1BAD27C800EC7113 /* struct.cpp in Sources */,
 				24F5550C1BAB906700EC7113 /* var.cpp in Sources */,
 				24F5551F1BAE122500EC7113 /* union.cpp in Sources */,
+				4A4A4E291F87C359009DE64F /* BlockParser.cpp in Sources */,
 				24F5550A1BAB906700EC7113 /* typedef.cpp in Sources */,
 				24F555121BAB906700EC7113 /* method.cpp in Sources */,
 				24F5550B1BAB906700EC7113 /* util.cpp in Sources */,

--- a/metabase/ios/lib/generate/util.js
+++ b/metabase/ios/lib/generate/util.js
@@ -924,7 +924,7 @@ function findBlock (json, signature, fn) {
 	if (blocks && blocks.length) {
 		for (c = 0; c < blocks.length; c++) {
 			block = blocks[c];
-			if (block && block.signature === signature) {
+			if (block && matchBlockSignature(block.signature, signature)) {
 				return block;
 			}
 		}
@@ -940,15 +940,40 @@ function findBlock (json, signature, fn) {
 		if (blocks && blocks.length) {
 			for (var f = 0; f < blocks.length; f++) {
 				block = blocks[f];
-				if (block && block.signature === signature) {
+				if (block && matchBlockSignature(block.signature, signature)) {
 					return block;
 				}
 			}
 		}
 	}
-	console.log(JSON.stringify(fn,null,2));
-	console.error("Couldn't find block with signature:", signature, "for framework:", fn.framework, ", function:", fn);
+	console.error("Couldn't find block with signature:", signature, "for framework:", fn.framework);
 	process.exit(1);
+}
+
+/**
+ * Matches two block signatures against each other to see if they are the same.
+ *
+ * Sometimes the metabase generator outputs slightly different signatures which
+ * describe the same block, e.g. void (^)(_Bool) and void (^)(BOOL). This
+ * function tries to normalize both signatures and then matches them again if
+ * a direct comparison yields no match.
+ *
+ * @param {String} signature Block signature
+ * @param {String} otherSignature Other block signature to match against
+ * @return {Boolean} True if both signatures match, false if not
+ */
+function matchBlockSignature(signature, otherSignature) {
+	if (signature === otherSignature) {
+		return true;
+	}
+
+	var normalizedSignature = signature.replace(/_Bool|bool/, 'BOOL');
+	var normalizedOtherSignature = otherSignature.replace(/_Bool|bool/, 'BOOL');
+	if (normalizedSignature === normalizedOtherSignature) {
+		return true;
+	}
+
+	return false;
 }
 
 function generateObjCValue (state, json, fn, arg, name, define, tab, arglist) {

--- a/metabase/ios/src/BlockParser.cpp
+++ b/metabase/ios/src/BlockParser.cpp
@@ -1,0 +1,49 @@
+//
+//  BlockParser.cpp
+//  hyperloop-metabase
+//
+//  Created by Jan Vennemann on 06.10.17.
+//  Copyright © 2017 Appcelerator, Inc. All rights reserved.
+//
+
+#include "BlockParser.h"
+#include "parser.h"
+#include "util.h"
+
+namespace hyperloop {
+  /**
+   * Parses the parameter of a block and adds it to our metabase if it's another block
+   *
+   * @param cursor Cursor to the parameter
+   * @param parent Cursor to the block the paremeter belongs to
+   * @param clientData Can be cast to the MethodDefinition the block is an argument for
+   * @return Always continue traversing argument siblings, so return CXChildVisit_Continue
+   */
+  static CXChildVisitResult parseBlockParameter(CXCursor cursor, CXCursor parent, CXClientData clientData) {
+    auto definition = static_cast<Definition *>(clientData);
+    auto paremterType = clang_getCursorType(cursor);
+    auto typeSpelling = CXStringToString(clang_getTypeSpelling(paremterType));
+    auto type = new Type(definition->getContext(), paremterType, typeSpelling);
+
+    if (type->getType() == "block") {
+      BlockParser::parseBlock(definition, cursor, type);
+    }
+
+    return CXChildVisit_Continue;
+  }
+
+  /**
+   * Recursively parses a block and its parameters for further block definitions.
+   *
+   * @param definition The symbol definition the block was found in
+   * @param cursor Cursor to the block
+   * @param type Type information of the block
+   */
+  void BlockParser::parseBlock(Definition *definition, CXCursor cursor, Type *type) {
+    auto context = definition->getContext();
+    auto framework = definition->getFramework();
+    context->getParserTree()->addBlock(framework, type->getValue());
+
+    clang_visitChildren(cursor, parseBlockParameter, definition);
+  }
+}

--- a/metabase/ios/src/BlockParser.h
+++ b/metabase/ios/src/BlockParser.h
@@ -1,0 +1,22 @@
+//
+//  BlockParser.h
+//  hyperloop-metabase
+//
+//  Created by Jan Vennemann on 06.10.17.
+//  Copyright © 2017 Appcelerator, Inc. All rights reserved.
+//
+
+#ifndef BlockParser_h
+#define BlockParser_h
+
+#include <stdio.h>
+#include "def.h"
+
+namespace hyperloop {
+  class BlockParser {
+  public:
+    static void parseBlock(Definition *definition, CXCursor cursor, Type *type);
+  };
+}
+
+#endif /* BlockParser_h */

--- a/metabase/ios/src/function.cpp
+++ b/metabase/ios/src/function.cpp
@@ -24,6 +24,7 @@ namespace hyperloop {
 				auto typeValue= CXStringToString(clang_getTypeSpelling(argType));
 				auto encoding = CXStringToString(clang_getDeclObjCTypeEncoding(cursor));
 				functionDef->addArgument(displayName, argType, typeValue, encoding);
+				addBlockIfFound(functionDef, cursor);
 				break;
 			}
 			case CXCursor_ObjCClassRef:
@@ -59,7 +60,6 @@ namespace hyperloop {
 		if (type->getType() == "unexposed") {
 			type->setType(EncodingToType(encoding));
 		}
-		addBlockIfFound(this->getContext(), this, this->getFramework(), type, encoding);
 		arguments.add(argName, type, filterEncoding(encoding));
 	}
 
@@ -85,7 +85,7 @@ namespace hyperloop {
 		auto returnTypeValue = CXStringToString(clang_getTypeSpelling(clang_getCursorResultType(cursor)));
 		this->returnType = new Type(context, returnType, returnTypeValue);
 		this->variadic = clang_isFunctionTypeVariadic(clang_getCursorType(cursor));
-		addBlockIfFound(context, this, this->getFramework(), this->returnType, "");
+		addBlockIfFound(this, cursor);
 		context->getParserTree()->addFunction(this);
 		clang_visitChildren(cursor, parseFunctionMember, this);
 		return CXChildVisit_Continue;

--- a/metabase/ios/src/struct.cpp
+++ b/metabase/ios/src/struct.cpp
@@ -24,7 +24,7 @@ namespace hyperloop {
 					type->setType(EncodingToType(encoding));
 				}
 				structDef->addField(displayName, type, encoding);
-				addBlockIfFound(structDef->getContext(), structDef, structDef->getFramework(), type, encoding);
+				addBlockIfFound(structDef, cursor);
 				break;
 			}
 			case CXCursor_UnexposedAttr: {

--- a/metabase/ios/src/typedef.cpp
+++ b/metabase/ios/src/typedef.cpp
@@ -8,6 +8,7 @@
 #include "util.h"
 #include "struct.h"
 #include "union.h"
+#include "BlockParser.h"
 
 namespace hyperloop {
 
@@ -80,7 +81,7 @@ namespace hyperloop {
 		std::string encoding = CXStringToString(clang_getDeclObjCTypeEncoding(cursor));
 		this->setType(type, encoding);
 		context->getParserTree()->addType(this);
-		addBlockIfFound(context, this, this->getFramework(), type, encoding);
+		addBlockIfFound(this, cursor);
 		return CXChildVisit_Continue;
 	}
 

--- a/metabase/ios/src/union.cpp
+++ b/metabase/ios/src/union.cpp
@@ -20,7 +20,7 @@ namespace hyperloop {
 				auto encoding = CXStringToString(clang_getDeclObjCTypeEncoding(cursor));
 				auto type = new Type(unionDef->getContext(), argType);
 				unionDef->addField(displayName, type, encoding);
-				hyperloop::addBlockIfFound(unionDef->getContext(), unionDef, unionDef->getFramework(), type, encoding);
+				hyperloop::addBlockIfFound(unionDef, cursor);
 				break;
 			}
 			case CXCursor_UnexposedAttr: {

--- a/metabase/ios/src/util.cpp
+++ b/metabase/ios/src/util.cpp
@@ -13,6 +13,7 @@
 #include "union.h"
 #include "typedef.h"
 #include "enum.h"
+#include "BlockParser.h"
 
 namespace hyperloop {
 	/**
@@ -837,9 +838,12 @@ namespace hyperloop {
 	/**
 	 * add a block if found as a type
 	 */
-	void addBlockIfFound (ParserContext *context, const Definition *definition, const std::string &framework, Type *type, const std::string &encoding) {
+	void addBlockIfFound (Definition *definition, CXCursor cursor) {
+		auto cursorType = clang_getCursorType(cursor);
+		auto typeSpelling = CXStringToString(clang_getTypeSpelling(cursorType));
+		auto type = new Type(definition->getContext(), cursorType, typeSpelling);
 		if (type->getType() == "block") {
-			context->getParserTree()->addBlock(framework, type->getValue());
+			BlockParser::parseBlock(definition, cursor, type);
 		}
 	}
 

--- a/metabase/ios/src/util.h
+++ b/metabase/ios/src/util.h
@@ -133,7 +133,7 @@ namespace hyperloop {
 	/**
 	 * add a block if found as a type
 	 */
-	void addBlockIfFound (ParserContext *context, const Definition *definition, const std::string &framework, Type *type, const std::string &encoding);
+	void addBlockIfFound (Definition *definition, CXCursor cursor);
 
 	/**
 	 * parse a block signature and return the returns value and place any args in the

--- a/metabase/ios/src/var.cpp
+++ b/metabase/ios/src/var.cpp
@@ -59,7 +59,7 @@ namespace hyperloop {
 		this->type = new Type(context, type);
 		tree->addVar(this);
 		clang_visitChildren(cursor, parseVarMember, this);
-		addBlockIfFound(context, this, this->getFramework(), this->type, encoding);
+		addBlockIfFound(this, cursor);
 		return CXChildVisit_Continue;
 	}
 


### PR DESCRIPTION
Follow up fix for https://jira.appcelerator.org/browse/TIMOB-25341

Makes sure to always pars blocks in a recursive manner to catch nested blocks. Also contains a fix for slightly different block signatures so they properly match again.