### PR TITLE
Fix iOS build-issues

### DIFF
--- a/iphone/build.sh
+++ b/iphone/build.sh
@@ -61,6 +61,8 @@ cp ../LICENSE build/zip/modules/iphone/hyperloop/$VERSION
 echo "Installing npm dependency..."
 cd build/zip/plugins/hyperloop/hooks/ios
 npm install findit --production >/dev/null 2>&1
+npm install fs-extra --production >/dev/null 2>&1
+
 rm -rf node_modules/findit/test
 rm -rf package-lock.json
 cd $CWD

--- a/iphone/plugins/hyperloop/hooks/ios/package.json
+++ b/iphone/plugins/hyperloop/hooks/ios/package.json
@@ -22,6 +22,7 @@
 	"license": "LicenseRef-LICENSE",
 	"dependencies": {
 		"findit": "^2.0.0",
-		"hyperloop-metabase": "*"
+		"hyperloop-metabase": "*",
+		"fs-extra": "^4.0.2"
 	}
 }


### PR DESCRIPTION
- The `fs-extra` dependency will missing in the packaged .zip due to dependency-issues

Successfully tested with `hyperloop-examples` now - The Swift-example works as well. Backport only if this one get's accepted.