### PR TITLE
[TIMOB-25399] Windows: Bump apiversion, drop Windows Phone/Store 8.1 support

### DIFF
--- a/windows/CMakeLists.txt.ejs
+++ b/windows/CMakeLists.txt.ejs
@@ -41,6 +41,7 @@ list(INSERT CMAKE_MODULE_PATH 0 ${APPCELERATOR_CMAKE_MODULE_PATH})
 find_package(HAL REQUIRED)
 find_package(TitaniumKit REQUIRED)
 find_package(TitaniumWindows_Utility REQUIRED)
+find_package(JavaScriptCore REQUIRED)
 
 set(SOURCE_Hyperloop
   include/Hyperloop.hpp
@@ -68,6 +69,7 @@ target_include_directories(Hyperloop PUBLIC
   )
 
 target_link_libraries(Hyperloop
+  JavaScriptCore
   HAL
   TitaniumKit
   TitaniumWindows_Utility

--- a/windows/cmake/FindJavascriptCore.cmake
+++ b/windows/cmake/FindJavascriptCore.cmake
@@ -1,61 +1,40 @@
-# HAL
+# FindJavaScriptCore
+# Author: Chris Williams
 #
 # Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
 # Licensed under the terms of the Apache Public License.
 # Please see the LICENSE included with this distribution for details.
 
-# Author: Matt Langston
-# Created: 2014.09.03
-#
-# Try to find JavaScriptCore. Once done this will define:
-#
-#  JavaScriptCore_FOUND       - system has JavaScriptCore
-#  JavaScriptCore_INCLUDE_DIRS - the include directory
-#  JavaScriptCore_LIBRARY_DIR - the directory containing the library
-#  JavaScriptCore_LIBRARIES   - link these to use JavaScriptCore
+# Author: Chris Williams
+# Created: 2014.12.02
 
-find_package(PkgConfig)
-
-pkg_check_modules(PC_JavaScriptCore QUIET JavaScriptCore)
-
-find_path(JavaScriptCore_INCLUDE_DIRS
-  NAMES JavaScriptCore/JavaScript.h
-  HINTS ${PC_JavaScriptCore_INCLUDE_DIRS} ${PC_JavaScriptCore_INCLUDEDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES includes
-  )
+if (${CMAKE_SYSTEM_VERSION} MATCHES "^10.0")
+  set(PLATFORM win10)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsPhone")
+  set(PLATFORM phone)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "WindowsStore")
+  set(PLATFORM store)
+else()
+  message(FATAL_ERROR "This app supports Store / Phone only.")
+endif()
 
 set(JavaScriptCore_ARCH "x86")
 if(CMAKE_GENERATOR MATCHES "^Visual Studio .+ ARM$")
   set(JavaScriptCore_ARCH "arm")
 endif()
 
-find_library(JavaScriptCore_LIBRARIES
-  NAMES JavaScriptCore JavaScriptCore-Debug JavaScriptCore-Release
-  HINTS ${PC_JavaScriptCore_LIBRARY_DIRS} ${PC_JavaScriptCore_LIBDIR}
-  PATHS ENV JavaScriptCore_HOME
-  PATH_SUFFIXES ${JavaScriptCore_ARCH}
+# Taken and slightly modified from build's JavaScriptCore_Targets.cmake file
+# INTERFACE_INCLUDE_DIRECTORIES is modified to point to our pre-packaged include dir for module
+
+# Create imported target JavaScriptCore
+add_library(JavaScriptCore SHARED IMPORTED)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  COMPATIBLE_INTERFACE_STRING "JavaScriptCore_MAJOR_VERSION"
+  INTERFACE_JavaScriptCore_MAJOR_VERSION "0"
+)
+
+set_target_properties(JavaScriptCore PROPERTIES
+  IMPORTED_IMPLIB "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.lib"
+  IMPORTED_LOCATION "${WINDOWS_SOURCE_DIR}/lib/JavaScriptCore/${PLATFORM}/${JavaScriptCore_ARCH}/JavaScriptCore.dll"
   )
-
-if(NOT JavaScriptCore_LIBRARIES MATCHES ".+-NOTFOUND")
-  get_filename_component(JavaScriptCore_LIBRARY_DIR ${JavaScriptCore_LIBRARIES} DIRECTORY)
-
-  # If we found the JavaScriptCore library and we're using a Visual
-  # Studio generator and we're targeting either WindowsStore or
-  # WindowsPhone, then allow Visual Studio to use both the
-  # JavaScriptCore-Debug.lib and JavaScriptCore-Release.lib if they
-  # exist.
-  if(CMAKE_GENERATOR MATCHES "^Visual Studio .+" AND CMAKE_SYSTEM_NAME MATCHES "^Windows(Store|Phone)")
-    string(REGEX REPLACE "-(Debug|Release)" "-$(Configuration)" JavaScriptCore_LIBRARIES ${JavaScriptCore_LIBRARIES})
-  endif()
-
-endif()
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JavaScriptCore DEFAULT_MSG JavaScriptCore_INCLUDE_DIRS JavaScriptCore_LIBRARIES)
-
-# message(STATUS "MDL: CMAKE_CONFIGURATION_TYPES   = ${CMAKE_CONFIGURATION_TYPES}")
-# message(STATUS "MDL: JAVASCRIPTCORE_FOUND        = ${JAVASCRIPTCORE_FOUND}")
-# message(STATUS "MDL: JavaScriptCore_INCLUDE_DIRS = ${JavaScriptCore_INCLUDE_DIRS}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARY_DIR  = ${JavaScriptCore_LIBRARY_DIR}")
-# message(STATUS "MDL: JavaScriptCore_LIBRARIES    = ${JavaScriptCore_LIBRARIES}")

--- a/windows/manifest
+++ b/windows/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: VERSION
-apiversion: 3
+apiversion: 4
 architectures: ARM x86
 description: hyperloop
 author: Appcelerator
@@ -17,4 +17,4 @@ moduleIdAsIdentifier: Hyperloop
 classname: HyperloopModule
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: windows
-minsdk: 6.1.1
+minsdk: 7.0.0

--- a/windows/plugins/hyperloop/hooks/windows/hyperloop.js
+++ b/windows/plugins/hyperloop/hooks/windows/hyperloop.js
@@ -27,22 +27,7 @@ exports.init = function(logger, config, cli, nodeappc) {
             },
         ];
 
-        var w81support = !isVS2017(data);
-
-        // Visual Studio 2017 doesn't support Windows/Phone 8.1 project anymore
-        if (w81support) {
-            tasks.push(function(next) {
-                runCmake(data, 'WindowsPhone', 'Win32', '8.1', next);
-            });
-            tasks.push(function(next) {
-                runCmake(data, 'WindowsPhone', 'ARM', '8.1', next);
-            });
-            tasks.push(function(next) {
-                runCmake(data, 'WindowsStore', 'Win32', '8.1', next);
-            });
-        }
-
-        var archs = w81support ? ['phone', 'store', 'win10'] : ['win10'];
+        var archs = ['win10'];
 
         var csharp_dest = path.join(data.projectDir, 'reflection', 'HyperloopInvocation');
         archs.forEach(function(platform) {
@@ -65,8 +50,7 @@ exports.init = function(logger, config, cli, nodeappc) {
      * Copy dependencies
      */
     cli.on('build.module.pre.package', function (data, callback) {
-        var w81support = !isVS2017(data),
-            archs = w81support ? ['phone', 'store', 'win10'] : ['win10'];
+        var archs = ['win10'];
 
         archs.forEach(function(platform){
             ['ARM', 'x86'].forEach(function(arch){


### PR DESCRIPTION
JIRA ticket: [TIMOB-25399](https://jira.appcelerator.org/browse/TIMOB-25399)

As of `Titanium SDK 7.0.0`, we are going to drop support for Windows (Store/Phone) 8.1. Hyperloop needs to be dropping support for them too. Since we are going to have significant internal changes (such as JavaScriptCore upgrade), the module apiversion will be bumped to `4`.

Note: This needs https://github.com/appcelerator/titanium_mobile_windows/pull/1145 to be merged.