### PR TITLE
[TIMOB-25403] Unwrap blocks from typedefs

### DIFF
--- a/metabase/ios/src/util.cpp
+++ b/metabase/ios/src/util.cpp
@@ -840,6 +840,9 @@ namespace hyperloop {
 	 */
 	void addBlockIfFound (Definition *definition, CXCursor cursor) {
 		auto cursorType = clang_getCursorType(cursor);
+		if (cursorType.kind == CXType_Typedef) {
+			cursorType = clang_getCanonicalType(clang_getTypedefDeclUnderlyingType(cursor));
+		}
 		auto typeSpelling = CXStringToString(clang_getTypeSpelling(cursorType));
 		auto type = new Type(definition->getContext(), cursorType, typeSpelling);
 		if (type->getType() == "block") {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25403

Typedefs need to be unwrapped first to see if their underlying type is a block so we can then parse it.