### PR TITLE
Prepare release 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Bump version number to trigger a new build because the currently available 2.2.1 build somehow got corrupted. 

To be sure this does not happen again we should let QE test the new build. Is it possible to make the build available in preprod only, so we can also check the downloaded version?