### PR TITLE
Set minsdk to 7.0.0 for iOS

### DIFF
--- a/iphone/manifest
+++ b/iphone/manifest
@@ -8,11 +8,11 @@ architectures: armv7 arm64 i386 x86_64
 description: hyperloop
 author: Appcelerator
 license: Appcelerator Commercial License
-copyright: Copyright (c) 2016 by Appcelerator, Inc.
+copyright: Copyright (c) 2016-Present by Appcelerator, Inc.
 
 # these should not be edited
 name: hyperloop
 moduleid: hyperloop
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: iphone
-minsdk: 5.4.0
+minsdk: 7.0.0


### PR DESCRIPTION
Bumps the apiversion to 4 and sets the minimum SDK to 7.0.0

Version bumps for Android in #179 and Windows in #232 