### PR TITLE
[TIMOB-25059] Guard against undefined plugins property

### DIFF
--- a/hooks/hyperloop-init.js
+++ b/hooks/hyperloop-init.js
@@ -7,6 +7,10 @@ exports.id = 'com.appcelerator.hyperloop.init';
 exports.cliVersion = '>=3.2';
 exports.init = (logger, config, cli, appc) => {
 	cli.on('cli:check-plugins', () => {
+		if (!Array.isArray(cli.tiapp.plugins)) {
+			return;
+		}
+
 		for (const plugin of cli.tiapp.plugins) {
 			if (plugin.id === 'hyperloop') {
 				logger.error('Legacy Hyperloop plugin detected! Please remove any references to the Hyperloop "<plugin>" tag from your tiapp.xml. Since Hyperloop 3.0 you only need to enable it as a module.');


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25059

If no plugins at all are defined in tiapp.xml the plugins property is undefined rather than initialized as an empty array. This guard checks for those cases, e.g. in a new classic app.