### PR TITLE
[TIMOB-25604] Improve compatibility with CocoaPods

### DIFF
--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -613,7 +613,7 @@ HyperloopiOSBuilder.prototype.generateSourceFiles = function generateSourceFiles
 	}
 	if (this.hyperloopConfig.ios.thirdparty) {
 		// Throw a deprecation warning regarding thirdparty-references in the appc.js
-		this.logger.warn('Defining third-party sources and frameworks in appc.js via the \'thirdparty\' section has been deprecated in Hyperloop 2.2.0 and will be removed in 3.0.0. The preferred way to provide third-party sources is either via dropping frameworks into the project\'s platform/ios folder or by using CocoaPods.');
+		this.logger.warn('Defining third-party sources and frameworks in appc.js via the \'thirdparty\' section has been deprecated in Hyperloop 2.2.0 and will be removed in 4.0.0. The preferred way to provide third-party sources is either via dropping frameworks into the project\'s platform/ios folder or by using CocoaPods.');
 
 		this.headers = [];
 		Object.keys(this.hyperloopConfig.ios.thirdparty).forEach(function(frameworkName) {

--- a/packages/hyperloop-ios-metabase/lib/generate/code-generator.js
+++ b/packages/hyperloop-ios-metabase/lib/generate/code-generator.js
@@ -197,8 +197,11 @@ class CodeGenerator {
 			});
 			var classWithSameNameExists = this.json.classes[moduleInfo.name] ? true : false;
 			if (classWithSameNameExists) {
-				var classPathAndFilename = path.join(outputPath, moduleInfo.framework, moduleInfo.name + '.js');
-				var classContent = fs.readFileSync(classPathAndFilename);
+				var classPathAndFilename = path.join(outputPath, moduleInfo.framework.toLowerCase(), moduleInfo.name.toLowerCase() + '.js');
+				var classContent = '';
+				if (fs.existsSync(classPathAndFilename)) {
+					classContent = fs.readFileSync(classPathAndFilename);
+				}
 				classContent += jsCode;
 				fs.writeFileSync(classPathAndFilename, classContent);
 			} else {


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-25604

If a Pod is only available as a dynamic framework but the use_frameworks! flag is missing, CocoaPods will create a dummy directory in its public header path and link all headers to the backing framework. This fix prevents duplicate parsing of those headers, which caused some follow up issues within the metabase parser.

@hansemannn With this i also deprecated the usage of CocoaPods without the `use_frameworks!` flag. Frameworks provide some additional information which makes it easier to create a sophisticate matabase from them compared to static libraries.