### PR TITLE
Use 7.0.x for iOS/Android and 7.1.x for Windows build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ import com.axway.AppcCLI;
 def nodeVersion = '8.9.0'
 def platformEnvironment = 'prod' // 'preprod'
 def credentialsId = '895d8db1-87c2-4d96-a786-349c2ed2c04a' // preprod = '65f9aaaf-cfef-4f22-a8aa-b1fb0d934b64'
-def sdkVersion = '7.1.1.v20180329185637' // Use master build with Windows DLL & removed 8.1, newer v8 api level *and* Android ARM64 support
+def sdkVersion = '7.0.0.v20171108114616' // Use master build with Windows DLL & removed 8.1, newer v8 api level *and* Android ARM64 support
+def sdkVersionForWindows = '7.1.1.v20180329185637' // Only used for Windows build
 def androidAPILevel = '26'
 
 // gets assigned once we read the package.json file
@@ -186,7 +187,7 @@ google.apis=${androidSDK}/add-ons/addon-google_apis-google-${androidAPILevel}
 
 					nodejs(nodeJSInstallationName: "node ${nodeVersion}") {
 						appc.install()
-						def activeSDKPath = appc.installAndSelectSDK(sdkVersion)
+						def activeSDKPath = appc.installAndSelectSDK(sdkVersionForWindows)
 
 						echo 'Building Windows module...'
 						// FIXME How the hell is Windows OK with these shell commands?


### PR DESCRIPTION
It is reported that Android-emulator crashes on Windows with Hyperloop. I'm not sure why it happens, but I could guess it might be because we updated Titanium SDK to build Hyperloop module. 

This PR is just to meant to get a workaround, this basically reverts the Ti sdk version (7.0.x) for iOS/Android and then changes to use specific sdk (7.1.x) for Windows.