### PR TITLE
build version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Update version to `3.1.0` just because I want to trigger 3.1.0 build in order to get the artifact. Once we get the module zip (and then hopefully release to hyperloop-builds) I am happy to revert this.
