### PR TITLE
[TIMOB-26097] Check for struct fields existence before iterating

### DIFF
--- a/iphone/hooks/generate/util.js
+++ b/iphone/hooks/generate/util.js
@@ -760,7 +760,7 @@ function generateFieldSetter (state, json, prop, index) {
 		var indent = repeat('\t', 5);
 		prop.otherStruct = otherStruct;
 		code.push('set: function (_' + prop.name + ') {');
-		otherStruct.fields.forEach(function (field, i) {
+		otherStruct.fields && otherStruct.fields.forEach(function (field, i) {
 			code.push(indent + 'this.$' + prop.name + '.' + field.name + ' = _' + prop.name + '.' + field.name + ';');
 		});
 		code.push(repeat('\t', 4) + '}');


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-26097

The build failed on generating the struct [MPSPackgedFloat3](https://developer.apple.com/documentation/metalperformanceshaders/mpspackedfloat3?language=objc) from the new MPS framework from iOS 12. This struct uses a union which is not supported in Hyperloop so there were no fields causing the crash.