### PR TITLE
[TIMOB-26328] Android: Fix releasing of InstanceProxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
- `InstanceProxy.releaseViews()` would cause a recursive cycle that eventually overflows the stack
- Amend `InstanceProxy.release()` and `InstanceProxy.releaseViews()` to correctly release the proxy

##### TEST CASE
1. Build [hyperloop-examples](https://github.com/appcelerator/hyperloop-examples)
2. Open `Button` example
3. Press Back
4. Application should not crash

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-26328)