### PR TITLE
chore: update deprecation message

### DIFF
--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -717,7 +717,7 @@ HyperloopiOSBuilder.prototype.generateSourceFiles = function generateSourceFiles
 	}
 	if (this.hyperloopConfig.ios.thirdparty) {
 		// Throw a deprecation warning regarding thirdparty-references in the appc.js
-		this.logger.warn('Defining third-party sources and frameworks in appc.js via the \'thirdparty\' section has been deprecated in Hyperloop 2.2.0 and will be removed in 4.0.0. The preferred way to provide third-party sources is either via dropping frameworks into the project\'s platform/ios folder or by using CocoaPods.');
+		this.logger.warn('Defining third-party sources and frameworks in appc.js via the \'thirdparty\' section has been deprecated in Hyperloop 2.2.0 and will be removed in 5.0.0. The preferred way to provide third-party sources is either via dropping frameworks into the project\'s platform/ios folder or by using CocoaPods.');
 
 		this.headers = [];
 		Object.keys(this.hyperloopConfig.ios.thirdparty).forEach(function (frameworkName) {


### PR DESCRIPTION
update the deprecation message due to postponed removal of appc.js third-party configuration in version 5.0.0

part of [TIMOB-26732](https://jira.appcelerator.org/browse/TIMOB-26732)