### PR TITLE
chore(windows): update Titanium SDK for Windows builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ import com.axway.AppcCLI;
 // Tweak these if you want to test against different nodejs or environment
 def nodeVersion = '8.9.0'
 def sdkVersion = '8.0.0.v20190115162133' // Use master build with TiCore / Kroll-Thread removal
+def sdkVersion_windows = '8.0.0.v20190308114556' // Use master build with module apiversion 7
 def androidAPILevel = '26'
 
 // gets assigned once we read the package.json file
@@ -166,7 +167,7 @@ stage('Build') {
 							ensureNPM()
 							withEnv(["PATH+NPM=${env.APPDATA}\\npm"]) { // fix PATH for Windows, blah
 								titanium.install()
-								def activeSDKPath = titanium.installAndSelectSDK(sdkVersion)
+								def activeSDKPath = titanium.installAndSelectSDK(sdkVersion_windows)
 
 								echo 'Building Windows module...'
 								dir('windows') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",

--- a/windows/manifest
+++ b/windows/manifest
@@ -3,7 +3,7 @@
 # during compilation, packaging, distribution, etc.
 #
 version: VERSION
-apiversion: 6
+apiversion: 7 
 architectures: ARM x86
 description: hyperloop
 author: Appcelerator
@@ -17,4 +17,4 @@ moduleIdAsIdentifier: Hyperloop
 classname: HyperloopModule
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: windows
-minsdk: 7.3.0
+minsdk: 8.0.0


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-26888

- Add compatibility with SDK 8.0.0
  - Update to `apiversion` 7
  - Use Titanium SDK `8.0.0.v20190308114556` only for Windows builds
- Bump up version: release v4.0.2