### PR TITLE
fix(ios): only use pod scripts if they are available

### DIFF
--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -1369,37 +1369,55 @@ HyperloopiOSBuilder.prototype.updateXcodeProject = function updateXcodeProject()
 	});
 
 	if (this.hasCocoaPods) {
-		var embedPodsFrameworksBuildPhaseId = generateUuid();
-		var embedPodsFrameworksBuildPhase = {
-			isa: 'PBXShellScriptBuildPhase',
-			buildActionMask: 2147483647,
-			files: [],
-			inputPaths: [],
-			name: '"[CP] Embed Pods Frameworks"',
-			outputPaths: [],
-			runOnlyForDeploymentPostprocessing: 0,
-			shellPath: '/bin/sh',
-			shellScript: '"\\"${PODS_ROOT}/Target Support Files/Pods-' + appName + '/Pods-' + appName + '-frameworks.sh\\""',
-			showEnvVarsInLog: 0
-		};
-		xobjs.PBXShellScriptBuildPhase[embedPodsFrameworksBuildPhaseId] = embedPodsFrameworksBuildPhase;
-		mainTarget.buildPhases.push(embedPodsFrameworksBuildPhaseId);
+		const frameworksScriptPath = path.join(
+			this.builder.projectDir,
+			'Pods',
+			'Target Support Files',
+			`Pods-${appName}`,
+			`Pods-${appName}-frameworks.sh`
+		);
+		if (fs.existsSync(frameworksScriptPath)) {
+			const embedPodsFrameworksBuildPhaseId = generateUuid();
+			const embedPodsFrameworksBuildPhase = {
+				isa: 'PBXShellScriptBuildPhase',
+				buildActionMask: 2147483647,
+				files: [],
+				inputPaths: [],
+				name: '"[CP] Embed Pods Frameworks"',
+				outputPaths: [],
+				runOnlyForDeploymentPostprocessing: 0,
+				shellPath: '/bin/sh',
+				shellScript: '"\\"${PODS_ROOT}/Target Support Files/Pods-' + appName + '/Pods-' + appName + '-frameworks.sh\\""',
+				showEnvVarsInLog: 0
+			};
+			xobjs.PBXShellScriptBuildPhase[embedPodsFrameworksBuildPhaseId] = embedPodsFrameworksBuildPhase;
+			mainTarget.buildPhases.push(embedPodsFrameworksBuildPhaseId);
+		}
 
-		var copyPodsResourcesBuildPhaseId = generateUuid();
-		var copyPodsResourcesBuildPhase = {
-			isa: 'PBXShellScriptBuildPhase',
-			buildActionMask: 2147483647,
-			files: [],
-			inputPaths: [],
-			name: '"[CP] Copy Pods Resources"',
-			outputPaths: [],
-			runOnlyForDeploymentPostprocessing: 0,
-			shellPath: '/bin/sh',
-			shellScript: '"\\"${PODS_ROOT}/Target Support Files/Pods-' + appName + '/Pods-' + appName + '-resources.sh\\""',
-			showEnvVarsInLog: 0
-		};
-		xobjs.PBXShellScriptBuildPhase[copyPodsResourcesBuildPhaseId] = copyPodsResourcesBuildPhase;
-		mainTarget.buildPhases.push(copyPodsResourcesBuildPhaseId);
+		const resourcesScriptPath = path.join(
+			this.builder.projectDir,
+			'Pods',
+			'Target Support Files',
+			`Pods-${appName}`,
+			`Pods-${appName}-resources.sh`
+		);
+		if (fs.existsSync(resourcesScriptPath)) {
+			var copyPodsResourcesBuildPhaseId = generateUuid();
+			var copyPodsResourcesBuildPhase = {
+				isa: 'PBXShellScriptBuildPhase',
+				buildActionMask: 2147483647,
+				files: [],
+				inputPaths: [],
+				name: '"[CP] Copy Pods Resources"',
+				outputPaths: [],
+				runOnlyForDeploymentPostprocessing: 0,
+				shellPath: '/bin/sh',
+				shellScript: '"\\"${PODS_ROOT}/Target Support Files/Pods-' + appName + '/Pods-' + appName + '-resources.sh\\""',
+				showEnvVarsInLog: 0
+			};
+			xobjs.PBXShellScriptBuildPhase[copyPodsResourcesBuildPhaseId] = copyPodsResourcesBuildPhase;
+			mainTarget.buildPhases.push(copyPodsResourcesBuildPhaseId);
+		}
 	}
 
 	if (this.hasCustomShellScriptBuildPhases()) {


### PR DESCRIPTION
In CocoaPods versions 1.6.0+ framework and resource bundling scripts will only be generated of they are actually needed. This will make sure to only include them in our Xcode project if they were generated.

Closes [TIMOB-26991](https://jira.appcelerator.org/browse/TIMOB-26991)