### PR TITLE
fix(ios): handle new external vector type

### DIFF
--- a/packages/hyperloop-ios-metabase/include/clang-c/BuildSystem.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/BuildSystem.h
@@ -1,9 +1,9 @@
 /*==-- clang-c/BuildSystem.h - Utilities for use by build systems -*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/include/clang-c/CXCompilationDatabase.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/CXCompilationDatabase.h
@@ -1,9 +1,9 @@
 /*===-- clang-c/CXCompilationDatabase.h - Compilation database  ---*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/include/clang-c/CXErrorCode.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/CXErrorCode.h
@@ -1,9 +1,9 @@
 /*===-- clang-c/CXErrorCode.h - C Index Error Codes  --------------*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/include/clang-c/CXString.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/CXString.h
@@ -1,9 +1,9 @@
 /*===-- clang-c/CXString.h - C Index strings  --------------------*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/include/clang-c/Documentation.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/Documentation.h
@@ -1,9 +1,9 @@
 /*==-- clang-c/Documentation.h - Utilities for comment processing -*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/include/clang-c/Index.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/Index.h
@@ -1,9 +1,9 @@
 /*===-- clang-c/Index.h - Indexing Public C Interface -------------*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|
@@ -32,7 +32,7 @@
  * compatible, thus CINDEX_VERSION_MAJOR is expected to remain stable.
  */
 #define CINDEX_VERSION_MAJOR 0
-#define CINDEX_VERSION_MINOR 50
+#define CINDEX_VERSION_MINOR 59
 
 #define CINDEX_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                       \
@@ -221,7 +221,12 @@ enum CXCursor_ExceptionSpecificationKind {
   /**
    * The exception specification has not been parsed yet.
    */
-  CXCursor_ExceptionSpecificationKind_Unparsed
+  CXCursor_ExceptionSpecificationKind_Unparsed,
+
+  /**
+   * The cursor has a __declspec(nothrow) exception specification.
+   */
+  CXCursor_ExceptionSpecificationKind_NoThrow
 };
 
 /**
@@ -1341,7 +1346,17 @@ enum CXTranslationUnit_Flags {
   /**
    * Used to indicate that implicit attributes should be visited.
    */
-  CXTranslationUnit_VisitImplicitAttributes = 0x2000
+  CXTranslationUnit_VisitImplicitAttributes = 0x2000,
+
+  /**
+   * Used to indicate that non-errors from included files should be ignored.
+   *
+   * If set, clang_getDiagnosticSetFromTU() will not report e.g. warnings from
+   * included files anymore. This speeds up clang_getDiagnosticSetFromTU() for
+   * the case where these warnings are not of interest, as for an IDE for
+   * example, which typically shows only the diagnostics in the main file.
+   */
+  CXTranslationUnit_IgnoreNonErrorsFromIncludedFiles = 0x4000
 };
 
 /**
@@ -2531,7 +2546,11 @@ enum CXCursorKind {
    */
   CXCursor_OMPTargetTeamsDistributeSimdDirective = 279,
 
-  CXCursor_LastStmt = CXCursor_OMPTargetTeamsDistributeSimdDirective,
+  /** C++2a std::bit_cast expression.
+   */
+  CXCursor_BuiltinBitCastExpr = 280,
+
+  CXCursor_LastStmt = CXCursor_BuiltinBitCastExpr,
 
   /**
    * Cursor that represents the translation unit itself.
@@ -2586,7 +2605,11 @@ enum CXCursorKind {
   CXCursor_ObjCRuntimeVisible            = 435,
   CXCursor_ObjCBoxable                   = 436,
   CXCursor_FlagEnum                      = 437,
-  CXCursor_LastAttr                      = CXCursor_FlagEnum,
+  CXCursor_ConvergentAttr                = 438,
+  CXCursor_WarnUnusedAttr                = 439,
+  CXCursor_WarnUnusedResultAttr          = 440,
+  CXCursor_AlignedAttr                   = 441,
+  CXCursor_LastAttr                      = CXCursor_AlignedAttr,
 
   /* Preprocessing */
   CXCursor_PreprocessingDirective        = 500,
@@ -3311,7 +3334,9 @@ enum CXTypeKind {
   CXType_OCLIntelSubgroupAVCImeResultDualRefStreamout = 173,
   CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
 
-  CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175
+  CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175,
+
+  CXType_ExtVector = 176
 };
 
 /**
@@ -3838,7 +3863,11 @@ enum CXTypeLayoutError {
   /**
    * The Field name is not valid for this record.
    */
-  CXTypeLayoutError_InvalidFieldName = -5
+  CXTypeLayoutError_InvalidFieldName = -5,
+  /**
+   * The type is undeduced.
+   */
+  CXTypeLayoutError_Undeduced = -6
 };
 
 /**
@@ -3911,10 +3940,22 @@ CINDEX_LINKAGE CXType clang_Type_getModifiedType(CXType T);
 CINDEX_LINKAGE long long clang_Cursor_getOffsetOfField(CXCursor C);
 
 /**
+ * Determine whether the given cursor represents an anonymous
+ * tag or namespace
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isAnonymous(CXCursor C);
+
+/**
  * Determine whether the given cursor represents an anonymous record
  * declaration.
  */
-CINDEX_LINKAGE unsigned clang_Cursor_isAnonymous(CXCursor C);
+CINDEX_LINKAGE unsigned clang_Cursor_isAnonymousRecordDecl(CXCursor C);
+
+/**
+ * Determine whether the given cursor represents an inline namespace
+ * declaration.
+ */
+CINDEX_LINKAGE unsigned clang_Cursor_isInlineNamespace(CXCursor C);
 
 enum CXRefQualifierKind {
   /** No ref-qualifier was provided. */

--- a/packages/hyperloop-ios-metabase/include/clang-c/Platform.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/Platform.h
@@ -1,9 +1,9 @@
 /*===-- clang-c/Platform.h - C Index platform decls   -------------*- C -*-===*\
 |*                                                                            *|
-|*                     The LLVM Compiler Infrastructure                       *|
-|*                                                                            *|
-|* This file is distributed under the University of Illinois Open Source      *|
-|* License. See LICENSE.TXT for details.                                      *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|

--- a/packages/hyperloop-ios-metabase/src/function.cpp
+++ b/packages/hyperloop-ios-metabase/src/function.cpp
@@ -33,7 +33,8 @@ namespace hyperloop {
 			case CXCursor_ConstAttr:
 			case CXCursor_PureAttr:
 			case CXCursor_VisibilityAttr:
-			case CXCursor_NSReturnsRetained: {
+			case CXCursor_NSReturnsRetained:
+			case CXCursor_WarnUnusedResultAttr: {
 				break;
 			}
 			default: {

--- a/packages/hyperloop-ios-metabase/src/union.cpp
+++ b/packages/hyperloop-ios-metabase/src/union.cpp
@@ -29,10 +29,10 @@ namespace hyperloop {
 				break;
 			}
 			default: {
-				std::cerr << "not handled, union: " << displayName << " kind: " << kind << std::endl;
-				std::map<std::string, std::string> location;
-				hyperloop::getSourceLocation(cursor, unionDef->getContext(), location);
-				std::cout << "union: " << displayName << " kind: " << kind << ", " << hyperloop::toJSON(location) << std::endl;
+				// std::cerr << "not handled, union: " << displayName << " kind: " << kind << std::endl;
+				// std::map<std::string, std::string> location;
+				// hyperloop::getSourceLocation(cursor, unionDef->getContext(), location);
+				// std::cout << "union: " << displayName << " kind: " << kind << ", " << hyperloop::toJSON(location) << std::endl;
 				break;
 			}
 		}

--- a/packages/hyperloop-ios-metabase/src/util.cpp
+++ b/packages/hyperloop-ios-metabase/src/util.cpp
@@ -618,6 +618,11 @@ namespace hyperloop {
 			case CXType_MemberPointer: {
 				return "member_pointer";
 			}
+			case CXType_ExtVector: {
+				// fallback to unexposed since external vectors have no encoding yet
+				// @see http://llvm.org/viewvc/llvm-project?view=revision&revision=216301
+				return "unexposed";
+			}
 			default: {
 				std::stringstream ss;
 				ss << "unknown type: ";


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-27824

The bundled clang lib in Xcode 11.4 adds a new external vector type. Our metabase parser didn't know about it and bailed out because this particular type has now encoding  yet (see http://llvm.org/viewvc/llvm-project?view=revision&revision=216301).

The fix for this is two fold. First, I updated the libclang headers so our metabase parser knows about the new type `CXType_ExtVector`. It will fallback to treat this as `unexposed`, which was the previous value for this type. Due to the missing encoding for this type we can't support it right now.

Second, i added a check that handles possible future unknown types by only spitting out a warning instead of failing the whole build. Internally these types will be handled the same as unknown/unexposed types that the metabase parser is aware of.