### PR TITLE
fix(android): rebuilds should release gradle file locks

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: hyperloop-android
 moduleid: hyperloop
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: android
-minsdk: 9.0.0
+minsdk: 9.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27882

**Summary:**
- Updated hyperloop version to `5.0.4`.
- Updated Android min Titanium SDK version to `9.0.2`.
  * Depends on new `gradle-wrapper.js` APIs.
- Hyperloop clean now runs gradle "clean" task to release gradle daemon's file locks.
  * Was preventing Windows from deleting files when building with Titanium `9.0.1`.
