### PR TITLE
fix(ios): remove bridged cast for SEL

### DIFF
--- a/iphone/hooks/generate/util.js
+++ b/iphone/hooks/generate/util.js
@@ -578,7 +578,7 @@ function getObjCReturnResult (value, name, returns, asPointer) {
 			break;
 		}
 		case 'SEL': {
-			return returns + ' (' + name + ' == nil) ? (id)[NSNull null] : (id)[HyperloopPointer pointer:(__bridge void *)' + asPointer + name +' encoding:@encode(SEL)];';
+			return returns + ' (' + name + ' == nil) ? (id)[NSNull null] : (id)[HyperloopPointer pointer:(const void *)' + asPointer + name +' encoding:@encode(SEL)];';
 		}
 		case 'void': {
 			return returns + ' nil;';


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/TIMOB-28099

The `SEL` type is defined as a char pointer in the objective-c runtime, which means it can directly be casted to a void pointer and does not need a bridged cast.