### PR TITLE
build: use SDK 9.2.0 to build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ import com.axway.AppcCLI;
 
 // Tweak these if you want to test against different nodejs or environment
 def nodeVersion = '10.17.0'
-def sdkVersion = '9.0.0.v20200130113429'
+def sdkVersion = '9.2.0.v20200915123928'
 def androidAPILevel = '26'
 
 // gets assigned once we read the package.json file
@@ -122,7 +122,7 @@ stage('Build') {
 			} // node
 		},
 		'iOS': {
-			node('osx && xcode-11') {
+			node('osx && xcode-12') {
 				try {
 					checkout scm
 

--- a/iphone/titanium.xcconfig
+++ b/iphone/titanium.xcconfig
@@ -1,5 +1,7 @@
 // define this is running locally but don't check in your change
 
-TITANIUM_SDK = ~/Library/Application Support/Titanium/mobilesdk/osx/8.0.2.GA
+TI_SDK_VERSION = 9.2.0.GA
+
+TITANIUM_SDK = /Users/${USER}/Library/Application Support/Titanium/mobilesdk/osx/${TI_SDK_VERSION}
 HEADER_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/include"
-FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks"
+FRAMEWORK_SEARCH_PATHS = $(inherited) "$(TITANIUM_SDK)/iphone/Frameworks/**"


### PR DESCRIPTION
Build with SDK 9.2.0 to use new .xcframework packaging.