### PR TITLE
fix(ios): exclude arm64 and i386 sim builds explicitly

### DIFF
--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -1589,6 +1589,7 @@ HyperloopiOSBuilder.prototype.hookXcodebuild = function hookXcodebuild(data) {
 	// speed up the build by only building the target architecture
 	if (this.builder.deployType === 'development' && this.builder.target === 'simulator') {
 		addParam('ONLY_ACTIVE_ARCH', 1);
+		addParam('EXCLUDED_ARCHS', 'arm64 i386'); // only build for x86_64!
 	}
 
 	// add any compiler specific flags


### PR DESCRIPTION
I don't necessarily think this is the final fix/answer here.

If you try to build our hyperloop-examples app for sim using the latest 9_2_X branch and hyperloop 6.0.0, it fails on Localytics Cocoapod, because it is trying to build for i386, x86_64 and arm64 sim. It barfs on the arm64 sim. In the SDK we try to detect frameworks that don't have arm64 sim support and explicitly exclude arm64 arch when building.

This PR basically turns off i386 and arm64 architectures on sim builds. 99% of the time, this is right. But it does mean whenever arm64 Apple Silicon devices ship, this will not do what we want (we basically just want to build for the current/active arch, but `ONLY_ACTIVE_ARCH` build setting seems to be ignored here)