### PR TITLE
fix: resolve elaborated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ---
 
+## [7.0.6] - 2023-11-18
+
+### Fixed
+
+- iOS: Fix compatibility with Xcode 15+ and iOS 17+
+
 ## [7.0.5] - 2023-05-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hyperloop",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hyperloop",
-      "version": "7.0.5",
+      "version": "7.0.6",
       "license": "UNLICENSED",
       "devDependencies": {
         "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperloop",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
     "appcelerator",

--- a/packages/hyperloop-ios-metabase/src/def.cpp
+++ b/packages/hyperloop-ios-metabase/src/def.cpp
@@ -81,6 +81,10 @@ namespace hyperloop {
 		if (type.kind == CXType_Typedef) {
 			type = clang_getCanonicalType(type);
 		}
+		// resolve elaborated to named type
+		if (type.kind == CXType_Elaborated) {
+			type = clang_Type_getNamedType(type);
+		}
 		typeSpelling = CXStringToString(clang_getTypeSpelling(type));
 		setType(hyperloop::CXTypeToType(type));
 		if (this->type != "block") {
@@ -105,7 +109,7 @@ namespace hyperloop {
 	}
 
 	Type::Type (CXCursor cursor, ParserContext *context) : Type(resolveCursorType(cursor), context) {
-		auto type = clang_getCursorType(cursor);
+		auto type = resolveCursorType(cursor);
 		if (type.kind == CXType_Typedef && this->getType() == "record") {
 			auto tree = this->context->getParserTree();
 			// we blindly assume that all structs have a typedef name without underscore prefix


### PR DESCRIPTION
This fixes an issue with elaborated types which were not properly resolved to their named type.

Example for elaborated types:

```c++
class A {};
 
int main()
{
    class A a; // OK: equivalent to 'A a;'
}
```

Fixes #380 