### PR TITLE
fix(android): update hyperloop android hook

### DIFF
--- a/android/hooks/hyperloop.js
+++ b/android/hooks/hyperloop.js
@@ -136,9 +136,11 @@ exports.cliVersion = '>=3.2';
 
 		// Copy our root "build.gradle" template script to the root build directory.
 		const templatesDir = path.join(this.builder.platformPath, 'templates', 'build');
-		await fs.copyFile(
-			path.join(templatesDir, 'root.build.gradle'),
-			path.join(this.hyperloopBuildDir, 'build.gradle'));
+		let rootBuildGradleContent = await fs.readFile(path.join(templatesDir, 'root.build.gradle'));
+		rootBuildGradleContent = ejs.render(rootBuildGradleContent.toString(), {
+			classpaths: [],
+		});
+		await fs.writeFile(path.join(this.hyperloopBuildDir, 'build.gradle'), rootBuildGradleContent);
 
 		// Copy our Titanium template's gradle constants file.
 		// This provides the Google library versions we use and defines our custom "AndroidManifest.xml" placeholders.


### PR DESCRIPTION
For the sake of PR  https://github.com/tidev/titanium-sdk/pull/14019

The android hook i copying the root.build.gradle file directly, and this file has been edited in the above mentioned PR for the sake of adding a new feature, and copying the file directly is causing a build error when trying to build hyperloop android module.