### PR TITLE
fix(android): fix writable dex file issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'com.linkedin.dexmaker:dexmaker:2.28.1'
+	implementation 'com.linkedin.dexmaker:dexmaker:2.28.4'
 }


### PR DESCRIPTION
Test:

Start hyperloop-examples (https://github.com/tidev/hyperloop-examples) and run "donut chart" or "custom drawing" on an Android 14 device. Most other examples including the "third-party libraries" work fine. I randomly clicked the "donut chart" and saw this issue:

```
[ERROR] TiExceptionHandler: Error: java.lang.SecurityException: Writable dex file '/data/user/0/com.appcelerator.sample.hyperloop/app_dx/v1/Generated_-1244563885.jar' is not allowed.
[ERROR] TiExceptionHandler:     at Function.View.extend (/hyperloop/android.view.View.js:62:32)
[ERROR] TiExceptionHandler:     at Activity.Controller.$.win.activity.onCreate (/alloy/controllers/donutchart.js:132:37)
```

https://github.com/linkedin/dexmaker/releases - 2.28.3 - `Make generated jar files read-only after creation #181`