### PR TITLE
feat(android): update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: macos-13
     name: Android
     env:
-      SDK_VERSION: 12.5.1.GA
+      SDK_VERSION: 12.8.0.GA
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '22'
         distribution: 'temurin'
 
     - name: Setup Android SDK
@@ -36,7 +36,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '22.x'
 
     - name: Cache Gradle packages
       uses: actions/cache@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-13
     name: iOS
     env:
-      SDK_VERSION: 12.4.0.GA
+      SDK_VERSION: 12.8.0.GA
       # This one uses Swift 3.8.1. If you're running into the "Unsupported Swift architecture", verify which
       # Swift version is used for the specified Ti SDK version, e.g. by looking into:
       # ~/Library/Application Support/Titanium/mobilesdk/osx/<version>/iphone/Frameworks/TitaniumKit.xcframework/ios-arm64/TitaniumKit.framework/Headers/TitaniumKit-Swift.h
@@ -40,7 +40,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '18.x'
+        node-version: '22.x'
 
     - name: Package metabase
       working-directory: ./packages/hyperloop-ios-metabase

--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: hyperloop-android
 moduleid: hyperloop
 guid: bdaca69f-b316-4ce6-9065-7a61e1dafa39
 platform: android
-minsdk: 9.0.0
+minsdk: 12.7.0


### PR DESCRIPTION
* 16kb page size support
* minsdk 12.7.0

[hyperloop-android-7.1.0.zip](https://github.com/user-attachments/files/22093369/hyperloop-android-7.1.0.zip)

NOTE: I think the repo builds the release. So we would need to change the github action to use the correct 12.8.1+ version. Otherwise we can manually release this ZIP above and once 13.0.0 is out we can change the action so it will build future version with that SDK