### PR TITLE
build(ci): use 13.0.0.GA

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-13
     name: Android
     env:
-      SDK_VERSION: 13.0.0.RC
+      SDK_VERSION: 13.0.0.GA
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-13
     name: iOS
     env:
-      SDK_VERSION: 13.0.0.RC
+      SDK_VERSION: 13.0.0.GA
       # This one uses Swift 3.8.1. If you're running into the "Unsupported Swift architecture", verify which
       # Swift version is used for the specified Ti SDK version, e.g. by looking into:
       # ~/Library/Application Support/Titanium/mobilesdk/osx/<version>/iphone/Frameworks/TitaniumKit.xcframework/ios-arm64/TitaniumKit.framework/Headers/TitaniumKit-Swift.h


### PR DESCRIPTION
This will pass once 13.0.0.GA has been released - just to be sure we don't have an RC version referenced too long.