### PR TITLE
fix: fixed typos & wording and updated keywords

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   android:
-    runs-on: macos-13
+    runs-on: macos-15
     name: Android
     env:
       SDK_VERSION: 13.0.0.GA

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ios:
-    runs-on: macos-13
+    runs-on: macos-15
     name: iOS
     env:
       SDK_VERSION: 13.0.0.GA

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,7 +21,7 @@ jobs:
       # ~/Library/Application Support/Titanium/mobilesdk/osx/<version>/iphone/Frameworks/TitaniumKit.xcframework/ios-arm64/TitaniumKit.framework/Headers/TitaniumKit-Swift.h
       #
       # An overview of macOS <> Xcode <> Swift versions can be found here: https://developer.apple.com/support/xcode/
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
 

--- a/android/hooks/tasks/generate-metabase-task.js
+++ b/android/hooks/tasks/generate-metabase-task.js
@@ -8,7 +8,7 @@ const metabase = require('../metabase');
  * A task that will generate the Android metabase
  *
  * This is implemented as a simple base task because the metabase generation
- * itself has a caching machanisim, so we just delegate and return the result.
+ * itself has a caching mechanism, so we just delegate and return the result.
  */
 class GenerateMetabaseTask extends BaseFileTask {
 
@@ -52,7 +52,7 @@ class GenerateMetabaseTask extends BaseFileTask {
 	}
 
 	/**
-	 * Gets the generated metabse
+	 * Gets the generated metabase
 	 *
 	 * @return {Object} Metabase object
 	 */

--- a/android/hooks/tasks/generate-sources-task.js
+++ b/android/hooks/tasks/generate-sources-task.js
@@ -41,7 +41,7 @@ class GenerateSourcesTask extends IncrementalFileTask {
 	}
 
 	/**
-	 * Metabase that will be used to genrate the warpper files
+	 * Metabase that will be used to generate the wrapper files
 	 *
 	 * @return {Object} Metabase object
 	 */
@@ -84,7 +84,7 @@ class GenerateSourcesTask extends IncrementalFileTask {
 	}
 
 	/**
-	 * Does a full task run, wich will generate the Hyperloop wrapper for every
+	 * Does a full task run, which will generate the Hyperloop wrapper for every
 	 * referenced Java class
 	 *
 	 * @return {Promise}
@@ -149,7 +149,7 @@ class GenerateSourcesTask extends IncrementalFileTask {
 	}
 
 	/**
-	 * Removes any unused class wrappers from the output directoy
+	 * Removes any unused class wrappers from the output directory
 	 *
 	 * @param {Array.<String>} classesToRemove Array of class names
 	 * @return {Promise}
@@ -259,7 +259,7 @@ class GenerateSourcesTask extends IncrementalFileTask {
 	/**
 	 * Loads the class list used in incremental task runs
 	 *
-	 * @return {Promise<Boolean>} True if the files was loaded succesfully, false if not
+	 * @return {Promise<Boolean>} True if the files was loaded successfully, false if not
 	 */
 	async loadClassList() {
 		try {

--- a/documentation/ios.md
+++ b/documentation/ios.md
@@ -353,7 +353,7 @@ module.exports = {
 };
 ```
 
-Any `flags` added to the `xcodebuild` property will be passed to `xcodebuild`. Any `frameworks` in the array provided will be automatically added to the xcode project.  _Note: any referenced frameworks in your Hyperloop code are automatically added for you. However, this gives you even more control to custom your compile environment._
+Any `flags` added to the `xcodebuild` property will be passed to `xcodebuild`. Any `frameworks` in the array provided will be automatically added to the Xcode project.  _Note: any referenced frameworks in your Hyperloop code are automatically added for you. However, this gives you even more control to custom your compile environment._
 
 ### Adding a third-party framework
 

--- a/hooks/hyperloop-init.js
+++ b/hooks/hyperloop-init.js
@@ -73,14 +73,14 @@ class HyperloopBuilderFactory {
 	 * @return {Object} Object with loaded config values
 	 */
 	loadConfiguration() {
-		const possibleConfigurtionFiles = [
+		const possibleConfigurationFiles = [
 			path.join(this.builder.projectDir, 'appc.js'),
 			path.join(this.builder.projectDir, '.appc.js'),
 			path.join(process.env.HOME || process.env.USERPROFILE, '.appc.js')
 		];
 		let config = {};
 
-		for (let configurationFile of possibleConfigurtionFiles) {
+		for (let configurationFile of possibleConfigurationFiles) {
 			if (fs.existsSync(configurationFile)) {
 				this.mergeObjectProperties(config, require(configurationFile));
 			}

--- a/iphone/hooks/generate/class.js
+++ b/iphone/hooks/generate/class.js
@@ -78,7 +78,7 @@ function makeClass(json, cls, state) {
  *  - The default Objective-C class name
  *  - The mangled class name for Swift classes
  *  - A combination of FrameworkName.ClassName for Objective-C classes that were
- *    impported from the Objective-C interface header of a Swift module.
+ *    imported from the Objective-C interface header of a Swift module.
  *
  * @param {Object} cls Class metadata object
  * @param {Object} state Parser state

--- a/iphone/hooks/generate/code-generator.js
+++ b/iphone/hooks/generate/code-generator.js
@@ -17,7 +17,7 @@ class CodeGenerator {
 	 *
 	 * @param {Object} sourceSet Set of source info objects passed to template files
 	 * @param {Object} modules Map of module info objects
-	 * @param {Object} iosBuilder iOS bulder instance
+	 * @param {Object} iosBuilder iOS builder instance
 	 */
 	constructor(sourceSet, modules, iosBuilder) {
 		this.sourceSet = sourceSet;
@@ -285,7 +285,7 @@ class CodeGenerator {
 	/**
 	 * Fixes custom module imports to use the correct framework header.
 	 *
-	 * Prior to dynamic framework support framework includes were simply genrated
+	 * Prior to dynamic framework support framework includes were simply generated
 	 * by assuming their umbrella header name. Dynamic frameworks that are written
 	 * in Swift provide an ObjC interface header which requires a different header
 	 * resolution. It is easier to fix this here afterwards than to do it in the
@@ -321,7 +321,7 @@ class CodeGenerator {
 	 * header imports.
 	 *
 	 * Prior to this we would simply assume umbrella headers as Framework/Framework.h,
-	 * which is a best practive though, but not every framework sticks to this.
+	 * which is a best practice though, but not every framework sticks to this.
 	 *
 	 * Utilizes the frameworks metadata to read the umbrella header from a framework's
 	 * module map or falls back to the old naming scheme.

--- a/iphone/hooks/generate/index.js
+++ b/iphone/hooks/generate/index.js
@@ -79,37 +79,37 @@ function processProtocolInheritance(protocols) {
 	 * Recursively merges a protocol with all it's inherited protocols
 	 *
 	 * @param {Object} protocol A protocol
-	 * @param {Number} logIntendationLevel Intendation level for debugging messages
+	 * @param {Number} logIndentationLevel Indentation level for debugging messages
 	 */
-	function mergeWithParentProtocols(protocol, logIntendationLevel) {
-		var logIntendationCharacter = '  ';
-		var logIntendation = logIntendationCharacter.repeat(logIntendationLevel++);
+	function mergeWithParentProtocols(protocol, logIndentationLevel) {
+		var logIndentationCharacter = '  ';
+		var logIndentation = logIndentationCharacter.repeat(logIndentationLevel++);
 		var parentProtocols = protocol.protocols;
 		var protocolSignature = parentProtocols ? protocol.name + ' <' + parentProtocols.join(', ') + '>' : protocol.name;
-		util.logger.trace(logIntendation + 'Processing inherited protocols of ' + protocolSignature);
-		logIntendation = logIntendationCharacter.repeat(logIntendationLevel);
+		util.logger.trace(logIndentation + 'Processing inherited protocols of ' + protocolSignature);
+		logIndentation = logIndentationCharacter.repeat(logIndentationLevel);
 
 		if (mergedProtocols.indexOf(protocol.name) !== -1) {
-			util.logger.trace(logIntendation + protocol.name + ' was already merged with all protocols it inherits from.');
+			util.logger.trace(logIndentation + protocol.name + ' was already merged with all protocols it inherits from.');
 			return;
 		}
 		if (!parentProtocols) {
-			util.logger.trace(logIntendation + protocol.name + ' does not inherit from any other protocols.');
+			util.logger.trace(logIndentation + protocol.name + ' does not inherit from any other protocols.');
 			mergedProtocols.push(protocol.name);
 			return;
 		}
 
-		util.logger.trace(logIntendation + 'Iterating over inherited protocols of ' + protocol.name);
-		logIntendationLevel++;
+		util.logger.trace(logIndentation + 'Iterating over inherited protocols of ' + protocol.name);
+		logIndentationLevel++;
 		protocol.protocols.forEach(function (parentProtocolName) {
 			if (protocol.name === parentProtocolName) {
-				util.logger.trace(logIntendation + 'Invalid protocol meta information. ' + protocol.name.red + ' cannot have itself as parent, skipping.');
+				util.logger.trace(logIndentation + 'Invalid protocol meta information. ' + protocol.name.red + ' cannot have itself as parent, skipping.');
 				return;
 			}
 			var parentProtocol = protocols[parentProtocolName];
-			mergeWithParentProtocols(parentProtocol, logIntendationLevel);
+			mergeWithParentProtocols(parentProtocol, logIndentationLevel);
 
-			util.logger.trace(logIntendation + 'Merging ' + parentProtocol.name.cyan + ' => ' + protocol.name.cyan);
+			util.logger.trace(logIndentation + 'Merging ' + parentProtocol.name.cyan + ' => ' + protocol.name.cyan);
 			protocol.properties = protocol.properties || {};
 			protocol.methods = protocol.methods || {};
 			merge(parentProtocol.properties, protocol.properties);
@@ -121,8 +121,8 @@ function processProtocolInheritance(protocols) {
 
 	Object.keys(protocols).forEach(function (protocolName) {
 		var protocol = protocols[protocolName];
-		var logIntendationLevel = 0;
-		mergeWithParentProtocols(protocol, logIntendationLevel);
+		var logIndentationLevel = 0;
+		mergeWithParentProtocols(protocol, logIndentationLevel);
 	});
 }
 

--- a/iphone/hooks/generate/util.js
+++ b/iphone/hooks/generate/util.js
@@ -688,13 +688,13 @@ function generateProp (state, json, prop, readonly, name) {
 }
 
 /**
- * Generates a view model used in the class template to generate soure
+ * Generates a view model used in the class template to generate source
  * code for class level properties
  *
  * @param {Object} templateVariables Holds all variable later used in the template
  * @param {Object} metabase The complete metabase object
  * @param {Object} propertyMeta Meta info for the current property
- * @return {Object} View model used inside the class tempalte
+ * @return {Object} View model used inside the class template
  */
 function generateClassProperty(templateVariables, metabase, propertyMeta) {
 	var viewModel = {name: propertyMeta.name};

--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -173,7 +173,7 @@ HyperloopiOSBuilder.prototype.validate = function validate() {
 		process.exit(1);
 	}
 
-	// check for min ios version
+	// check for min iOS version
 	if (this.appc.version.lt(this.builder.minIosVer, IOS_MIN)) {
 		this.logger.error('Hyperloop compiler works best with iOS ' + IOS_MIN + ' or greater.');
 		this.logger.error('Your setting is currently set to: ' + (this.builder.tiapp.ios['min-ios-ver'] || this.builder.minIosVer));
@@ -1240,7 +1240,7 @@ HyperloopiOSBuilder.prototype.updateXcodeProject = function updateXcodeProject()
 		}, this);
 	}
 
-	// add the source files to xcode to compile
+	// add the source files to Xcode to compile
 	if (nativeModules.length) {
 		groups['Native'] || (groups['Native'] = {});
 		nativeModules.forEach(function (mod) {
@@ -1426,7 +1426,7 @@ HyperloopiOSBuilder.prototype.hasCustomShellScriptBuildPhases = function hasCust
  * @param {Object} data - The hook payload.
  */
 HyperloopiOSBuilder.prototype.hookRemoveFiles = function hookRemoveFiles(data) {
-	// remove empty Framework directory that might have been created by cocoapods
+	// remove empty Framework directory that might have been created by CocoaPods
 	var frameworksDir = path.join(this.builder.xcodeAppDir, 'Frameworks');
 	if (fs.existsSync(frameworksDir) && fs.readdirSync(frameworksDir).length === 0) {
 		fs.removeSync(frameworksDir);

--- a/iphone/hooks/hyperloop.js
+++ b/iphone/hooks/hyperloop.js
@@ -460,7 +460,7 @@ HyperloopiOSBuilder.prototype.processJSFile = function processJSFile(obj, source
 
 				self.logger.trace('Checking require for: ' + pkg.toLowerCase() + '/' + className.toLowerCase());
 
-				// if the framework is not found, then check if it was possibly mispelled
+				// if the framework is not found, then check if it was possibly misspelled
 				if (!framework && !isBuiltin) {
 					const pkgSoundEx = soundEx(pkg);
 					const maybes = Array.from(self.frameworks.keys()).filter(function (frameworkName) {
@@ -524,7 +524,7 @@ HyperloopiOSBuilder.prototype.processJSFile = function processJSFile(obj, source
 				const isBuiltin = pkg === 'Titanium';
 				const framework = self.frameworks.get(pkg);
 
-				// if the framework is not found, then check if it was possibly mispelled
+				// if the framework is not found, then check if it was possibly misspelled
 				if (!framework && !isBuiltin) {
 					const pkgSoundEx = soundEx(pkg);
 					const maybes = Array.from(self.frameworks.keys()).filter(function (frameworkName) {
@@ -621,7 +621,7 @@ HyperloopiOSBuilder.prototype.generateSourceFiles = function generateSourceFiles
 			this.normalizeFrameworks(outfile);
 			this.determineFrameworkAvailability();
 		} else {
-			this.populateFrameworkAvailabiltyFromCache();
+			this.populateFrameworkAvailabilityFromCache();
 		}
 
 		if (cached && this.swiftSources.length === 0 && !this.forceMetabase) {
@@ -705,7 +705,7 @@ HyperloopiOSBuilder.prototype.generateSourceFiles = function generateSourceFiles
 		}, this);
 	}
 
-	// Framwork umbrella headers are required to propery resolve forward declarations
+	// Framework umbrella headers are required to properly resolve forward declarations
 	this.frameworks.forEach(frameworkMeta => {
 		if (!frameworkMeta.umbrellaHeader || !fs.existsSync(frameworkMeta.umbrellaHeader)) {
 			this.logger.warn(`Unable to detect framework umbrella header for ${frameworkMeta.name}.`);
@@ -843,7 +843,7 @@ HyperloopiOSBuilder.prototype.determineFrameworkAvailability = function determin
  * This only needs to be done in the main frameworks property since all other
  * Maps reference the same metadata objects.
  */
-HyperloopiOSBuilder.prototype.populateFrameworkAvailabiltyFromCache = function populateFrameworkAvailabiltyFromCache() {
+HyperloopiOSBuilder.prototype.populateFrameworkAvailabilityFromCache = function populateFrameworkAvailabilityFromCache() {
 	const cachePathAndFilename = path.join(this.hyperloopBuildDir, 'metadata-framework-availability.json');
 	let availabilityMap = {};
 	try {
@@ -1098,7 +1098,7 @@ HyperloopiOSBuilder.prototype.updateXcodeProject = function updateXcodeProject()
 			if (this.systemFrameworks.has(frameworkName)) {
 				frameworksToAdd.push(this.systemFrameworks.get(frameworkName));
 			} else {
-				this.logger.error(`Unable to link against non-existing system framework "${frameworkName}". Please check your appc.js configurtion.`);
+				this.logger.error(`Unable to link against non-existing system framework "${frameworkName}". Please check your appc.js configuration.`);
 				process.exit(1);
 			}
 		}, this);

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "version": "8.0.0",
   "description": "Access native APIs from within Titanium.",
   "keywords": [
-    "appcelerator",
     "titanium",
     "hyperloop",
     "android",
-    "ios",
-    "windows"
+    "ios"
   ],
   "author": "Jeff Haynie",
   "contributors": [

--- a/packages/hyperloop-ios-metabase/include/clang-c/BuildSystem.h
+++ b/packages/hyperloop-ios-metabase/include/clang-c/BuildSystem.h
@@ -118,7 +118,7 @@ clang_ModuleMapDescriptor_setFrameworkModuleName(CXModuleMapDescriptor,
                                                  const char *name);
 
 /**
- * Sets the umbrealla header name that the module.map describes.
+ * Sets the umbrella header name that the module.map describes.
  * \returns 0 for success, non-zero to indicate an error.
  */
 CINDEX_LINKAGE enum CXErrorCode

--- a/packages/hyperloop-ios-metabase/lib/metabase.js
+++ b/packages/hyperloop-ios-metabase/lib/metabase.js
@@ -19,7 +19,7 @@ var spawn = require('child_process').spawn,
 
 
 /**
- * return the configured SDK path
+ * Returns the configured SDK path
  */
 function getSDKPath (sdkType, callback) {
 	exec('/usr/bin/xcrun --sdk ' + sdkType + ' --show-sdk-path', function (err, stdout) {
@@ -29,7 +29,7 @@ function getSDKPath (sdkType, callback) {
 }
 
 /**
- * convert an apple style version (9.0) to a semver compatible version
+ * Converts an Apple style version (9.0) to a semver compatible version
  */
 function appleVersionToSemver (ver) {
 	var v = String(ver).split('.');
@@ -43,7 +43,7 @@ function appleVersionToSemver (ver) {
 }
 
 /**
- * return a parsed plist for a given framework
+ * Returns a parsed plist for a given framework
  */
 function getPlistForFramework (info, callback) {
 	if (fs.existsSync(info)) {
@@ -203,7 +203,7 @@ class ModuleMetadata {
 	}
 
 	/**
-	 * Prases a plain object received from JSON data and converts it back to a
+	 * Parses a plain object received from JSON data and converts it back to a
 	 * module metadata instance.
 	 *
 	 * @param {Object} json Object containing data from JSON
@@ -221,7 +221,7 @@ class ModuleMetadata {
 }
 
 /**
- * generate system framework includes mapping
+ * Generates system framework includes mapping
  */
 function generateSystemFrameworks (sdkPath, iosMinVersion, callback) {
 	const frameworksPath = path.resolve(path.join(sdkPath, 'System/Library/Frameworks'));
@@ -260,7 +260,7 @@ function generateSystemFrameworks (sdkPath, iosMinVersion, callback) {
  * mapped to the parent framework.
  *
  * @param {String} frameworkName Name of the framework
- * @param {String} frameworkPath Full path to the framwork
+ * @param {String} frameworkPath Full path to the framework
  * @param {Object} includes Object with all include mappings
  */
 function extractImplementationsFromFramework(frameworkName, frameworkPath, includes) {
@@ -276,7 +276,7 @@ function extractImplementationsFromFramework(frameworkName, frameworkPath, inclu
  * Iterates over a framework's Headers directory and any nested frameworks to
  * collect the paths to all available header files of a framework.
  *
- * @param {String} frameworkPath Full path to the framwork
+ * @param {String} frameworkPath Full path to the framework
  * @return {Array} List with paths to all found header files
  */
 function collectFrameworkHeaders(frameworkPath) {
@@ -300,11 +300,11 @@ function collectFrameworkHeaders(frameworkPath) {
 }
 
 /**
- * generate a metabase
+ * Generates a metabase
  *
  * @param {String} buildDir cache directory to write the files
- * @param {String} sdk the sdk type such as iphonesimulator
- * @param {String} sdk path the path to the SDK
+ * @param {String} sdk the SDK type such as iphonesimulator
+ * @param {String} sdkPath the path to the SDK
  * @param {String} iosMinVersion the min version such as 9.0
  * @param {Array} includes array of header paths (should be absolute paths)
  * @param {Boolean} excludeSystem if true, will exclude any system libraries in the generated output
@@ -413,7 +413,7 @@ function generateMetabase (buildDir, sdk, sdkPath, iosMinVersion, includes, excl
 }
 
 /**
- * return the system frameworks mappings as JSON for a given sdkType and minVersion
+ * Returns the system frameworks mappings as JSON for a given sdkType and minVersion
  */
 function getSystemFrameworks (cacheDir, sdkType, minVersion, callback) {
 	var fn = 'metabase-mappings-' + sdkType + '-' + minVersion + '.json';
@@ -456,7 +456,7 @@ function recursiveReadDir (dir, result) {
 }
 
 /**
- * for an array of directories, return all validate header files
+ * For an array of directories, returns all validate header files
  */
 function getAllHeaderFiles (directories) {
 	var files = [];
@@ -861,7 +861,7 @@ function getBuiltProductsRootPath (basePath, configurationName, sdkType) {
  * Gets JSON encoded data from a cache file.
  *
  * @param {String} cacheDir Path to the cache directory
- * @param {String} cacheToken Hash to identifiy the required cache file
+ * @param {String} cacheToken Hash to identify the required cache file
  * @return {Object} The CocoaPods metabase mappings
  */
 function readFromCache (cachePathAndFilename) {
@@ -939,7 +939,7 @@ function readModulesMetadataFromCache(cachePathAndFilename) {
 
 
 /**
- * handle buffer output
+ * Handles buffer output
  */
 function createLogger (obj, fn) {
 	return (function () {
@@ -965,7 +965,7 @@ function createLogger (obj, fn) {
 }
 
 /**
- * run the ibtool
+ * Runs the ibtool
  */
 function runIBTool (runDir, args, callback) {
 	var spawn = require('child_process').spawn,
@@ -1132,7 +1132,7 @@ function runCocoaPodsBuild (basedir, builder, callback) {
 }
 
 /**
- * parse the xcconfig file
+ * Parses the xcconfig file
  */
 function parseCocoaPodXCConfig (fn) {
 	var config = {};
@@ -1148,7 +1148,7 @@ function parseCocoaPodXCConfig (fn) {
 }
 
 /**
- * generate a map of xcode settings for CocoaPods
+ * Generates a map of Xcode settings for CocoaPods
  */
 function getCocoaPodsXCodeSettings (basedir) {
 	var podDir = path.join(basedir, 'Pods');

--- a/tools/ci.js
+++ b/tools/ci.js
@@ -361,7 +361,7 @@ function writeAndroidManifest(next) {
 }
 
 /**
- * write the updated ios manifest if necessary
+ * write the updated iOS manifest if necessary
  */
 function writeiOSManifest(next) {
 	var fn = path.join(__dirname, '..', 'iphone', 'manifest'),
@@ -378,7 +378,7 @@ function writeiOSManifest(next) {
 }
 
 /**
- * write the updated android plugin package.json if neccesary
+ * write the updated android plugin package.json if necessary
  */
 function writeAndroidPluginPackage (next) {
 	var fn = path.join(__dirname, '..', 'android', 'plugins', 'hyperloop', 'hooks', 'android', 'package.json'),
@@ -440,8 +440,7 @@ function build(branch, callback) {
 				next();
 			});
 		},
-		// TODO Do we need to install xcode or something?
-		// TODO Install python if it's not installed?
+		// TODO Do we need to install Xcode or something?
 
 		// Grab the paths to Android NDK and SDK
 		function (next) {


### PR DESCRIPTION
**Description**

Fixes in logs, comments and docs:
- fixed typos
- fixed a apidoc param
- fixed wording: `Apple`, `iOS`, `CocoaPods`, `SDK`, `Xcode`

 Fixes in code (not API-relevant):
- function `populateFrameworkAvailabiltyFromCache()` &rarr; `populateFrameworkAvailabilityFromCache()`
- variable `possibleConfigurtionFiles` &rarr; `possibleConfigurationFiles`
- variable infix/suffix `Intendation` &rarr; `Indentation`

Updates:
- removed keywords `appcelerator` and `windows` in `package.json`
- BTW increased macOS runner and Xcode version for GitHub Action