### PR TITLE
build(ios): added umbrella header not found warning

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   android:
-    runs-on: macos-13
+    runs-on: macos-15
     name: Android
     env:
       SDK_VERSION: 13.0.0.GA

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ios:
-    runs-on: macos-13
+    runs-on: macos-15
     name: iOS
     env:
       SDK_VERSION: 13.0.0.GA
@@ -21,7 +21,7 @@ jobs:
       # ~/Library/Application Support/Titanium/mobilesdk/osx/<version>/iphone/Frameworks/TitaniumKit.xcframework/ios-arm64/TitaniumKit.framework/Headers/TitaniumKit-Swift.h
       #
       # An overview of macOS <> Xcode <> Swift versions can be found here: https://developer.apple.com/support/xcode/
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
 

--- a/packages/hyperloop-ios-metabase/lib/metabase.js
+++ b/packages/hyperloop-ios-metabase/lib/metabase.js
@@ -245,6 +245,7 @@ function generateSystemFrameworks (sdkPath, iosMinVersion, callback) {
 
 			next();
 		} else {
+			util.logger.debug('No framework umbrella header found for ' + frameworkName + '. Skipping ...');
 			return next();
 		}
 	}, function (err) {


### PR DESCRIPTION
**Introduction**

- There is a umbrella header-related warning in https://github.com/tidev/hyperloop.next/blob/84ae716403f785b50130eadfff7d95bdaf66ef29/iphone/hooks/hyperloop.js#L711
but it's only raised if the framework metadata are wrong.
- If a framework hasn't an umbrella header (e.g. `TipKit`), the framework is skipped before this warning can occur.
  - I struggled with that in https://github.com/tidev/hyperloop.next/issues/407.
  
**Description**
  
- added a debug warning, if a framework hasn't an umbrella header
- BTW increased macOS runner and Xcode version for GitHub Action